### PR TITLE
Add component documentation for VG-LegalApp and VG-Frankensteiner

### DIFF
--- a/components/VG-Frankensteiner_v2_active_components/README.md
+++ b/components/VG-Frankensteiner_v2_active_components/README.md
@@ -1,0 +1,17 @@
+# VG-Frankensteiner Anything Engine — Component Index
+
+The **VG-Frankensteiner_v2_active** canvas is a two-page automation lab. Page one (Input Configuration) lets creators describe a desired "engine" in natural language, load reference banks, and fine-tune generation flags before hitting the Magic Box. Page two (Execution & Results) then exposes up to ten bots that can remix, extend, or critique the generated pipeline.
+
+## Experience Map
+- **Magic Box (Genie)** – Accepts a freeform description plus optional file, chosen model, and target bot count, then calls Poe to design a JSON engine template with live streaming feedback.
+- **Three Banks System** – Dedicated uploaders for Keys (techniques), Input payloads, and Prompt templates with status chips, previews, and download/export utilities.
+- **Execution Deck** – Ten themed bot panels, each with accordion-based model pickers, prompt health indicators, optional flag controls, execution buttons, and output transcript drawers.
+- **Global Utilities** – Persistent nav buttons for state save/load/export, a processing log timeline, per-bot clipboard/download helpers, and toggles for showing/hiding inactive bots.
+
+## Key Modules Extracted
+1. **Magic Box Layout & Flow** – `magic_box.md` captures the HTML controls, the full Genie architect prompt, and the JavaScript for executing the engine, handling streamed JSON, and revealing model-specific flags.
+2. **Accordion Model Picker** – `accordion_manager.md` documents the rebuilt accordion selector tailored for this app (with dual display/search states, provider/series toggles, and keyboard support).
+3. **Flag Manager** – `flag_manager.md` explains how dynamic tuning forms are injected per model, covering both Magic Box-wide and bot-specific flag containers.
+4. **Bot Panel Template** – `bot_panel_template.md` shows the reusable layout for each bot card, including status headings, prompt slots, execution controls, and output management bar.
+
+Each document blends the lifted template/code with usage notes so both builders and day-to-day operators can navigate the system confidently without touching the original canvas file.

--- a/components/VG-Frankensteiner_v2_active_components/accordion_manager.md
+++ b/components/VG-Frankensteiner_v2_active_components/accordion_manager.md
@@ -1,0 +1,496 @@
+# Accordion Model Picker (Rebuilt)
+
+## Model Database
+```js
+        const MODEL_DATABASE = {
+            "Favorites": [
+                "@GPT-5", "@GPT-4.1", "@o3-pro", "@o1", "@Gemini-2.5-Pro",
+                "@Claude-Opus-4-Reasoning", "@Claude-Opus-4.1", "@Claude-Opus-4-Search",
+                "@Claude-Sonnet-4-Search", "@Grok-4", "@Mistral-Large-2"
+            ],
+            "Web Search": [
+                "@Claude-Opus-4-Search", "@Claude-Sonnet-4-Search", "@Claude-Sonnet-3.7-Search",
+                "@Gemini-2.5-Flash", "@Gemini-2.5-Pro", "@Grok-4",
+                "@Perplexity-Sonar", "@Perplexity-Sonar-Rsn-Pro",
+                "@GPT-4o-Search", "@Linkup-Deep-Search", "@Linkup-Standard",
+                "@Bagoodex-Web-Search"
+            ],
+            "GPT": {
+                "GPT-5 Series": ["@GPT-5-Chat", "@GPT-5", "@GPT-5-mini", "@GPT-5-nano"],
+                "GPT-4 Series": [
+                    "@GPT-4.1", "@GPT-4o-Search", "@GPT-4-Classic", "@GPT-4-Classic-0314",
+                    "@GPT-4-Turbo", "@GPT-4.1-mini", "@GPT-4.1-nano", "@GPT-4o",
+                    "@GPT-4o-mini", "@GPT-4o-mini-Search", "@GPT-4o-Aug", "@ChatGPT-4o-Latest"
+                ],
+                "GPT-3.5 Series": ["@GPT-3.5-Turbo", "@GPT-3.5-Turbo-Instruct", "@GPT-3.5-Turbo-Raw"],
+                "o-Series": ["@o1", "@o3", "@o3-pro", "@o1-mini", "@o3-mini", "@o3-mini-high", "@o4-mini", "@o3-Pro"]
+            },
+            "GPT - Open Weight": {
+                "120B Models": ["@GPT-OSS-120B-T", "@GPT-OSS-120B", "@GPT-OSS-120B-CS", "@OpenAI-GPT-OSS-120B"],
+                "20B Models": ["@GPT-OSS-20B-T", "@GPT-OSS-20B", "@OpenAI-GPT-OSS-20B"]
+            },
+            "Google": {
+                "Gemini 2.5": [
+                    "@Gemini-2.5-Pro", "@Gemini-2.5-Flash", "@Gemini-2.5-Flash-Lite",
+                    "@Gemini-2.5-Flash-Lite-Preview", "@Gemini-2.5-Flash-Image"
+                ],
+                "Gemini 2.0": ["@Gemini-2.0-Flash", "@Gemini-2.0-Flash-Lite", "@Gemini-2.0-Flash-Preview"],
+                "Gemini 1.5": ["@Gemini-1.5-Pro", "@Gemini-1.5-Pro-Search", "@Gemini-1.5-Flash", "@Gemini-1.5-Flash-Search"],
+                "Gemma": ["@Gemma-3-27B", "@Gemma-2-27b-T"]
+            },
+            "Claude": {
+                "Opus": [
+                    "@Claude-Opus-4.1", "@Claude-Opus-4", "@Claude-Opus-4-Reasoning",
+                    "@Claude-Opus-4-Search", "@Claude-Opus-3"
+                ],
+                "Sonnet": [
+                    "@Claude-Sonnet-4", "@Claude-Sonnet-4-Reasoning", "@Claude-Sonnet-4-Search",
+                    "@Claude-Sonnet-3.5", "@Claude-Sonnet-3.5-June", "@Claude-Sonnet-3.5-Search",
+                    "@Claude-Sonnet-3.7", "@Claude-Sonnet-3.7-Reasoning", "@Claude-Sonnet-3.7-Search"
+                ],
+                "Haiku": ["@Claude-Haiku-3.5", "@Claude-Haiku-3", "@Claude-Haiku-3.5-Search"]
+            },
+            "Grok": ["@Grok-4", "@Grok-3", "@Grok-3-Mini", "@Grok-Code-Fast-1", "@Grok-2"],
+            "Llama 4": [
+                "@Llama-4-Scout-B10", "@Llama-4-Maverick", "@Llama-4-Scout-T",
+                "@Llama-4-Scout-CS", "@Llama-4-Scout", "@Llama-4-Maverick-T", "@Llama-4-Maverick-B10"
+            ],
+            "Llama 3.X": {
+                "405B Models": ["@Llama-3.1-405B", "@Llama-3.1-405B-T", "@Llama-3.1-405B-FW", "@Llama-3.1-405B-FP16"],
+                "70B Models": [
+                    "@Llama-3-70b-Groq", "@Llama-3.3-70B", "@Llama-3.1-Nemotron",
+                    "@Llama-3.3-70B-DI", "@Llama-3.3-70B-CS", "@Llama-3.3-70B-Vers",
+                    "@Llama-3-70B-FP16", "@Llama-3-70B-T", "@Llama-3.1-70B",
+                    "@Llama-3.1-70B-FP16", "@Llama-3.1-70B-FW", "@Llama-3.1-70B-T",
+                    "@Llama-3.3-70B-FW", "@Llama-3.3-70B-N"
+                ],
+                "8B Models": [
+                    "@Llama-3-8B-T", "@Llama-3-8b-Groq", "@Llama-3.1-8B",
+                    "@Llama-3.1-8B-CS", "@Llama-3.1-8B-DI", "@Llama-3.1-8B-FP16",
+                    "@Llama-3.1-8B-FW", "@Llama-3.1-8B-T-128k"
+                ]
+            },
+            "Qwen": {
+                "480B": ["@Qwen3-480B-Coder-CS", "@Qwen3-Coder-480B-T", "@Qwen3-Coder-480B-N"],
+                "235B": [
+                    "@Qwen-3-235B-2507-T", "@Qwen3-235B-2507-FW", "@Qwen3-235B-2507-CS",
+                    "@Qwen3-235B-A22B", "@Qwen3-235B-A22B-DI", "@Qwen3-235B-A22B-N", "@Qwen3-235B-Think-CS"
+                ],
+                "72B": ["@Qwen-72B-T", "@Qwen2-72B-Instruct-T", "@Qwen2.5-VL-72B-T", "@Qwen-2.5-72B-T"],
+                "32B": [
+                    "@Qwen3-30B-A3B-Instruct", "@Qwen2.5-Coder-32B", "@Qwen2.5-Coder-32B-T",
+                    "@Qwen3-32B-CS", "@Qwen3-Coder-30B-A3B"
+                ],
+                "Others": ["@Qwen-2.5-7B-T", "@Qwen-2.5-VL-32b", "@Qwen3-Coder"]
+            },
+            "DeepSeek": {
+                "R1 Series": [
+                    "@DeepSeek-R1", "@DeepSeek-R1-FW", "@DeepSeek-R1-DI", "@DeepSeek-R1-N",
+                    "@DeepSeek-R1-Distill", "@DeepSeek-R1-Turbo-DI"
+                ],
+                "V3 Series": [
+                    "@DeepSeek-V3.1", "@DeepSeek-V3.1-Chat", "@DeepSeek-V3.1-N",
+                    "@Deepseek-V3-FW", "@DeepSeek-V3", "@DeepSeek-V3-DI", "@DeepSeek-V3-Turbo-DI"
+                ],
+                "Specialized": ["@DeepSeek-Prover-V2", "@DeepClaude"]
+            },
+            "Mistral": {
+                "Large": ["@Mistral-Large-2"],
+                "Medium": ["@Mistral-Medium-3", "@Mistral-Medium", "@Magistral-Medium-2506-Thinking"],
+                "Small": [
+                    "@Mistral-Small-3.2", "@Mistral-Small-3.1", "@Mistral-Small-3",
+                    "@Mistral-7B-v0.3-DI", "@Mistral-7B-v0.3-T"
+                ],
+                "Specialized": ["@Mistral-NeMo", "@Mixtral8x22b-Inst-FW"]
+            },
+            "Perplexity": [
+                "@Perplexity-R1-1776", "@Perplexity-Sonar", "@Perplexity-Sonar-Pro",
+                "@Perplexity-Sonar-Rsn", "@Perplexity-Sonar-Rsn-Pro"
+            ],
+            "Others": [
+                "@Aya-Expanse-32B", "@Aya-Vision", "@Command-R", "@Command-R-Plus",
+                "@GLM-4.5", "@GLM-4.5-Air", "@GLM-4.5-Air-T", "@GLM-4.5-FW", "@GLM-4.5-Versatile",
+                "@GPT-Researcher", "@Inception-Mercury", "@Inception-Mercury-Coder",
+                "@Hermes-3-70B", "@Kimi-K2", "@Kimi-K2-0905-T", "@Kimi-K2-Instruct", "@Kimi-K2-T",
+                "@MiniMax-M1", "@Phi-4-DI", "@QwQ-32B-B10", "@QwQ-32B-Preview-T", "@QwQ-32B-T",
+                "@Reka-Core", "@Reka-Flash", "@Reka-Research", "@Tako", "@Solar-Pro-2"
+            ]
+        };
+
+        // Model Flags Database
+        const MODEL_FLAGS = {
+            "@Claude-Opus-4": { thinking_budget: { type: "slider", min: 0, max: 30768, default: "default" }},
+            "@Claude-Opus-4-Reasoning": { thinking_budget: { type: "slider", min: 0, max: 30768, default: "default" }},
+            "@Claude-Opus-4-Search": { thinking_budget: { type: "slider", min: 0, max: 126000, default: "default" }},
+            "@Claude-Opus-4.1": { thinking_budget: { type: "slider", min: 0, max: 31999, default: "default" }},
+            "@Claude-Sonnet-3.7": { thinking_budget: { type: "slider", min: 0, max: 16384, default: "default" }},
+            "@Claude-Sonnet-3.7-Reasoning": { thinking_budget: { type: "slider", min: 0, max: 126000, default: "default" }},
+            "@Claude-Sonnet-3.7-Search": { thinking_budget: { type: "slider", min: 0, max: 126000, default: "default" }},
+            "@Claude-Sonnet-4": { thinking_budget: { type: "slider", min: 0, max: 30768, default: "default" }},
+            "@Claude-Sonnet-4-Reasoning": { thinking_budget: { type: "slider", min: 0, max: 61440, default: "default" }},
+            "@Claude-Sonnet-4-Search": { thinking_budget: { type: "slider", min: 0, max: 126000, default: "default" }},
+            "@Gemini-2.5-Flash": { 
+                thinking_budget: { type: "slider_stepped", steps: [0, 4096, 8192, 12288, 16384, 20480, 24576], default: "default" }
+            },
+            "@Gemini-2.5-Flash-Lite": { 
+                thinking_budget: { type: "slider_stepped", steps: [0, 4096, 8192, 12288, 16384, 20480, 24576], default: "default" }
+            },
+            "@Gemini-2.5-Pro": { 
+                thinking_budget: { type: "slider_stepped", steps: [0, 4096, 8192, 12288, 16384, 20480, 24576, 28672, 32768], default: "default" }
+            },
+            "@GPT-5": { reasoning_effort: { type: "slider_stepped", steps: ["minimal", "low", "medium", "high"], default: "default" }},
+            "@GPT-5-mini": { reasoning_effort: { type: "slider_stepped", steps: ["minimal", "low", "medium", "high"], default: "default" }},
+            "@GPT-5-nano": { reasoning_effort: { type: "slider_stepped", steps: ["minimal", "low", "medium", "high"], default: "default" }},
+            "@o1": { reasoning_effort: { type: "slider_stepped", steps: ["low", "medium", "high"], default: "default" }},
+            "@o3": { reasoning_effort: { type: "slider_stepped", steps: ["low", "medium", "high"], default: "default" }},
+            "@o3-mini": { reasoning_effort: { type: "slider_stepped", steps: ["low", "medium", "high"], default: "default" }},
+            "@o3-pro": { reasoning_effort: { type: "slider_stepped", steps: ["low", "medium", "high"], default: "default" }},
+            "@o4-mini": { reasoning_effort: { type: "slider_stepped", steps: ["low", "medium", "high"], default: "default" }},
+            "@Grok-3-Mini": { reasoning_effort: { type: "slider_stepped", steps: ["low", "high"], default: "default" }},
+            "@Tako": { specificity: { type: "slider", min: 0, max: 100, default: "default" }},
+```
+
+## AccordionManager Class
+```js
+        class AccordionManager {
+            constructor(options = {}) {
+                this.options = {
+                    searchDebounceMs: 150,
+                    animationDuration: 300,
+                    ...options
+                };
+                
+                this.accordions = new Map();
+                this.expandedSections = new Map();
+                this.searchDebounceTimers = new Map();
+            }
+
+            createAccordion(containerId, data, config = {}) {
+                const accordion = {
+                    id: containerId,
+                    data: data,
+                    filteredData: data,
+                    isExpanded: false,
+                    selectedItem: null,
+                    searchTerm: '',
+                    callbacks: {
+                        onSelect: config.onSelect || (() => {}),
+                        onSearch: config.onSearch || (() => {}),
+                        onExpand: config.onExpand || (() => {}),
+                        onCollapse: config.onCollapse || (() => {})
+                    }
+                };
+
+                this.accordions.set(containerId, accordion);
+                this.initializeAccordionDOM(containerId);
+                return accordion;
+            }
+
+            initializeAccordionDOM(accordionId) {
+                const container = document.getElementById(accordionId);
+                if (!container) return;
+
+                // Build the accordion structure
+                container.innerHTML = `
+                    <div class="accordion-header" onclick="accordionManager.toggleAccordion('${accordionId}')">
+                        <div class="accordion-display">
+                            <span class="accordion-model-text">Select Model</span>
+                        </div>
+                        <div class="accordion-search-wrapper">
+                            <span class="accordion-search-icon">🔍</span>
+                            <input class="accordion-search-input" 
+                                   type="text"
+                                   placeholder="Search models..." 
+                                   onclick="event.stopPropagation()"
+                                   oninput="accordionManager.handleSearch('${accordionId}', this.value)" />
+                        </div>
+                        <span class="accordion-chevron">▼</span>
+                    </div>
+                    <div class="accordion-content-wrapper">
+                        <div class="accordion-content"></div>
+                    </div>
+                `;
+
+                // Set initial selected model if provided
+                const accordion = this.accordions.get(accordionId);
+                if (accordion && accordion.selectedItem) {
+                    this.updateSelectedDisplay(accordionId);
+                }
+            }
+
+            toggleAccordion(accordionId, forceState = null) {
+                const accordion = this.accordions.get(accordionId);
+                if (!accordion) return;
+
+                const container = document.getElementById(accordionId);
+                if (!container) return;
+
+                const wasExpanded = accordion.isExpanded;
+                accordion.isExpanded = forceState !== null ? forceState : !accordion.isExpanded;
+
+                // Close other accordions if opening this one
+                if (accordion.isExpanded && !wasExpanded) {
+                    this.accordions.forEach((other, otherId) => {
+                        if (otherId !== accordionId && other.isExpanded) {
+                            this.toggleAccordion(otherId, false);
+                        }
+                    });
+                }
+
+                // Update DOM state
+                if (accordion.isExpanded) {
+                    container.classList.add('expanded');
+                    
+                    // Focus search input
+                    setTimeout(() => {
+                        const searchInput = container.querySelector('.accordion-search-input');
+                        if (searchInput) {
+                            searchInput.focus();
+                        }
+                    }, 100);
+
+                    // Render content if needed
+                    const contentEl = container.querySelector('.accordion-content');
+                    if (contentEl && !contentEl.innerHTML.trim()) {
+                        this.renderAccordionContent(accordionId);
+                    }
+
+                    accordion.callbacks.onExpand(accordionId);
+                } else {
+                    container.classList.remove('expanded');
+                    
+                    // Clear search
+                    const searchInput = container.querySelector('.accordion-search-input');
+                    if (searchInput) {
+                        searchInput.value = '';
+                        accordion.searchTerm = '';
+                        accordion.filteredData = accordion.data;
+                    }
+
+                    accordion.callbacks.onCollapse(accordionId);
+                }
+            }
+
+            handleSearch(accordionId, searchTerm) {
+                // Clear existing debounce timer
+                if (this.searchDebounceTimers.has(accordionId)) {
+                    clearTimeout(this.searchDebounceTimers.get(accordionId));
+                }
+
+                // Set new debounce timer
+                const timer = setTimeout(() => {
+                    this.setSearchTerm(accordionId, searchTerm);
+                }, this.options.searchDebounceMs);
+
+                this.searchDebounceTimers.set(accordionId, timer);
+            }
+
+            setSearchTerm(accordionId, searchTerm) {
+                const accordion = this.accordions.get(accordionId);
+                if (!accordion) return;
+
+                accordion.searchTerm = searchTerm.toLowerCase();
+                accordion.filteredData = this.filterAccordionData(accordion.data, accordion.searchTerm);
+                
+                this.renderAccordionContent(accordionId);
+                accordion.callbacks.onSearch(searchTerm, accordion.filteredData);
+            }
+
+            renderAccordionContent(accordionId) {
+                const accordion = this.accordions.get(accordionId);
+                if (!accordion) return;
+
+                const container = document.getElementById(accordionId);
+                const contentEl = container?.querySelector('.accordion-content');
+                if (!contentEl) return;
+
+                let html = '';
+                let hasContent = false;
+
+                Object.entries(accordion.filteredData).forEach(([category, items]) => {
+                    const categoryContent = this.renderCategory(category, items, accordionId);
+                    if (categoryContent) {
+                        html += categoryContent;
+                        hasContent = true;
+                    }
+                });
+
+                if (!hasContent) {
+                    html = '<div class="accordion-empty">No models found</div>';
+                }
+
+                contentEl.innerHTML = html;
+
+                // Auto-expand sections when searching
+                if (accordion.searchTerm) {
+                    this.autoExpandSearchResults(accordionId);
+                }
+            }
+
+            renderCategory(category, items, accordionId) {
+                const accordion = this.accordions.get(accordionId);
+                const sectionKey = `${accordionId}-${category}`;
+                const isExpanded = this.expandedSections.get(sectionKey) || accordion.searchTerm;
+
+                // Get filtered items
+                const filteredItems = this.getFilteredItems(items, accordion.searchTerm);
+                if (filteredItems.length === 0 && accordion.searchTerm) return '';
+
+                let html = `
+                    <div class="accordion-section ${isExpanded ? 'expanded' : ''}" data-category="${category}">
+                        <div class="accordion-section-header" onclick="accordionManager.toggleSection('${accordionId}', '${category}')">
+                            <div class="accordion-section-info">
+                                <span>${category}</span>
+                                <span class="accordion-section-count">(${filteredItems.length})</span>
+                            </div>
+                            <span class="accordion-section-chevron">▶</span>
+                        </div>
+                        <div class="accordion-section-content">
+                `;
+
+                if (Array.isArray(items)) {
+                    // Simple array
+                    filteredItems.forEach(item => {
+                        html += this.renderItem(item, accordionId);
+                    });
+                } else {
+                    // Nested structure
+                    Object.entries(items).forEach(([subcategory, subitems]) => {
+                        const filteredSubitems = this.filterItems(subitems, accordion.searchTerm);
+                        if (filteredSubitems.length > 0) {
+                            html += `
+                                <div class="accordion-subsection">
+                                    <div class="accordion-subsection-header">${subcategory}</div>
+                            `;
+                            filteredSubitems.forEach(item => {
+                                html += this.renderItem(item, accordionId);
+                            });
+                            html += '</div>';
+                        }
+                    });
+                }
+
+                html += '</div></div>';
+                return html;
+            }
+
+            renderItem(item, accordionId) {
+                const accordion = this.accordions.get(accordionId);
+                const isSelected = accordion.selectedItem === item;
+                const displayName = item.startsWith('@') ? item.slice(1) : item;
+
+                return `
+                    <div class="accordion-item ${isSelected ? 'selected' : ''}"
+                         data-item="${item}"
+                         onclick="accordionManager.selectItem('${accordionId}', '${item.replace(/'/g, "\\'")}')"
+                         title="${displayName}">
+                        ${displayName}
+                    </div>
+                `;
+            }
+
+            getFilteredItems(items, searchTerm) {
+                if (Array.isArray(items)) {
+                    return this.filterItems(items, searchTerm);
+                } else {
+                    const result = [];
+                    Object.values(items).forEach(subitems => {
+                        if (Array.isArray(subitems)) {
+                            result.push(...this.filterItems(subitems, searchTerm));
+                        }
+                    });
+                    return result;
+                }
+            }
+
+            filterItems(items, searchTerm) {
+                if (!searchTerm || !Array.isArray(items)) return items;
+                return items.filter(item => 
+                    item.toLowerCase().includes(searchTerm)
+                );
+            }
+
+            filterAccordionData(data, searchTerm) {
+                if (!searchTerm) return data;
+
+                const filtered = {};
+                
+                Object.entries(data).forEach(([category, items]) => {
+                    if (Array.isArray(items)) {
+                        const filteredItems = this.filterItems(items, searchTerm);
+                        if (filteredItems.length > 0) {
+                            filtered[category] = filteredItems;
+                        }
+                    } else {
+                        const filteredSubcategories = {};
+                        Object.entries(items).forEach(([subcat, subitems]) => {
+                            const filteredSub = this.filterItems(subitems, searchTerm);
+                            if (filteredSub.length > 0) {
+                                filteredSubcategories[subcat] = filteredSub;
+                            }
+                        });
+                        if (Object.keys(filteredSubcategories).length > 0) {
+                            filtered[category] = filteredSubcategories;
+                        }
+                    }
+                });
+                
+                return filtered;
+            }
+
+            toggleSection(accordionId, category) {
+                const sectionKey = `${accordionId}-${category}`;
+                const isExpanded = this.expandedSections.get(sectionKey);
+                this.expandedSections.set(sectionKey, !isExpanded);
+                
+                const container = document.getElementById(accordionId);
+                const section = container?.querySelector(`[data-category="${category}"]`);
+                if (section) {
+                    section.classList.toggle('expanded', !isExpanded);
+                }
+            }
+
+            autoExpandSearchResults(accordionId) {
+                const container = document.getElementById(accordionId);
+                container?.querySelectorAll('.accordion-section').forEach(section => {
+                    section.classList.add('expanded');
+                    const category = section.dataset.category;
+                    if (category) {
+                        this.expandedSections.set(`${accordionId}-${category}`, true);
+                    }
+                });
+            }
+
+            selectItem(accordionId, item) {
+                const accordion = this.accordions.get(accordionId);
+                if (!accordion) return;
+
+                accordion.selectedItem = item;
+                this.updateSelectedDisplay(accordionId);
+                this.toggleAccordion(accordionId, false);
+                
+                accordion.callbacks.onSelect(item, accordionId);
+            }
+
+            updateSelectedDisplay(accordionId) {
+                const accordion = this.accordions.get(accordionId);
+                const container = document.getElementById(accordionId);
+                if (!accordion || !container) return;
+
+                const displayEl = container.querySelector('.accordion-model-text');
+                if (displayEl && accordion.selectedItem) {
+                    const displayName = accordion.selectedItem.startsWith('@') ? 
+                        accordion.selectedItem.slice(1) : accordion.selectedItem;
+                    displayEl.textContent = displayName;
+                }
+            }
+
+            getSelection(accordionId) {
+```
+
+## How it works
+- **Dual-mode header** flips between a compact "Select Model" display and a search input once expanded, keeping the collapsed state tiny while exposing full search when needed.
+- **Provider → Series → Model hierarchy** renders categories and subcategories on demand, preserving expansion state and auto-expanding when a search term is active.
+- **Debounced search** filters against the `MODEL_DATABASE`, updating counts inline and showing "No models found" when nothing matches.
+- **Single-open accordion** collapses other pickers when a new one opens, while `selectItem` writes the handle back into callbacks for downstream logic (model assignment, flag toggles, etc.).
+- **Utility helpers** (`getSelection`, `setSelection`, `clearSelection`, `destroy`) support state persistence and cleanup when users import/export configurations or hide bot panels.

--- a/components/VG-Frankensteiner_v2_active_components/bot_panel_template.md
+++ b/components/VG-Frankensteiner_v2_active_components/bot_panel_template.md
@@ -1,0 +1,56 @@
+# Bot Panel Template
+
+## Template
+```html
+<div id="bot1Container" class="mb-6 p-6 bg-gradient-to-r from-purple-50 to-pink-50 dark:from-purple-900/20 dark:to-pink-900/20 rounded-lg border border-purple-200 dark:border-purple-800">
+  <div class="mb-4">
+    <div class="flex items-center justify-between mb-3">
+      <h3 class="font-semibold text-purple-800 dark:text-purple-200 text-lg">🤖 Bot 1 - Initial Transformation</h3>
+      <span id="bot1Status" class="text-sm text-purple-600 dark:text-purple-400"></span>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+      <div>
+        <label class="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">Model Selection</label>
+        <div id="bot1Model" class="accordion-container"></div>
+      </div>
+      <div>
+        <label class="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">Prompt Status</label>
+        <div id="bot1PromptStatus" class="text-sm text-gray-600 dark:text-gray-400 p-2 bg-white dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700">
+          <span class="text-gray-500">No prompt loaded</span>
+        </div>
+      </div>
+    </div>
+
+    <div id="bot1Flags" class="hidden flag-container">
+      <div id="bot1FlagControls"></div>
+    </div>
+
+    <button id="executeBot1" class="w-full px-6 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors font-medium relative" onclick="executeBot(1)">
+      <span id="executeBot1Text">⚡ Execute Bot 1</span>
+      <div id="executeBot1Spinner" class="hidden absolute inset-0 flex items-center justify-center">
+        <div class="animate-spin rounded-full h-5 w-5 border-2 border-white border-t-transparent"></div>
+      </div>
+    </button>
+  </div>
+
+  <div class="border-t border-purple-200 dark:border-purple-700 pt-4">
+    <div class="flex items-center justify-between mb-2">
+      <h4 class="font-medium text-purple-700 dark:text-purple-300">Output</h4>
+      <div class="flex space-x-2">
+        <button onclick="copyBotOutput(1)" class="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300" title="Copy">📋</button>
+        <button onclick="downloadBotOutput(1)" class="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300" title="Download">💾</button>
+        <button onclick="clearBotOutput(1)" class="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300" title="Clear">🗑️</button>
+      </div>
+    </div>
+    <div id="bot1Output" class="prose dark:prose-invert max-w-none bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700 min-h-[100px] max-h-[400px] overflow-y-auto"></div>
+  </div>
+</div>
+```
+
+## How it works
+- **Status header** labels each bot's specialism and surfaces a live status span (`bot1Status`) that the execution logic updates during streaming.
+- **Model + prompt row** pairs the accordion picker with a prompt health tile so operators immediately see whether a template has been injected or needs attention.
+- **Flag container** stays hidden until `flagManager` detects configurable parameters for the selected model, then renders sliders, selects, or advanced forms inside `bot1FlagControls`.
+- **Execution control** swaps between text and spinner while `executeBot(1)` runs, ensuring each bot can signal busy/idle states independently.
+- **Output toolbar** standardises copy/download/clear actions across all panels, writing the rendered Markdown transcript into `bot1Output` for later review or export.

--- a/components/VG-Frankensteiner_v2_active_components/flag_manager.md
+++ b/components/VG-Frankensteiner_v2_active_components/flag_manager.md
@@ -1,0 +1,330 @@
+# Flag Manager
+
+## Model Flag Definitions
+```js
+        const MODEL_FLAGS = {
+            "@Claude-Opus-4": { thinking_budget: { type: "slider", min: 0, max: 30768, default: "default" }},
+            "@Claude-Opus-4-Reasoning": { thinking_budget: { type: "slider", min: 0, max: 30768, default: "default" }},
+            "@Claude-Opus-4-Search": { thinking_budget: { type: "slider", min: 0, max: 126000, default: "default" }},
+            "@Claude-Opus-4.1": { thinking_budget: { type: "slider", min: 0, max: 31999, default: "default" }},
+            "@Claude-Sonnet-3.7": { thinking_budget: { type: "slider", min: 0, max: 16384, default: "default" }},
+            "@Claude-Sonnet-3.7-Reasoning": { thinking_budget: { type: "slider", min: 0, max: 126000, default: "default" }},
+            "@Claude-Sonnet-3.7-Search": { thinking_budget: { type: "slider", min: 0, max: 126000, default: "default" }},
+            "@Claude-Sonnet-4": { thinking_budget: { type: "slider", min: 0, max: 30768, default: "default" }},
+            "@Claude-Sonnet-4-Reasoning": { thinking_budget: { type: "slider", min: 0, max: 61440, default: "default" }},
+            "@Claude-Sonnet-4-Search": { thinking_budget: { type: "slider", min: 0, max: 126000, default: "default" }},
+            "@Gemini-2.5-Flash": { 
+                thinking_budget: { type: "slider_stepped", steps: [0, 4096, 8192, 12288, 16384, 20480, 24576], default: "default" }
+            },
+            "@Gemini-2.5-Flash-Lite": { 
+                thinking_budget: { type: "slider_stepped", steps: [0, 4096, 8192, 12288, 16384, 20480, 24576], default: "default" }
+            },
+            "@Gemini-2.5-Pro": { 
+                thinking_budget: { type: "slider_stepped", steps: [0, 4096, 8192, 12288, 16384, 20480, 24576, 28672, 32768], default: "default" }
+            },
+            "@GPT-5": { reasoning_effort: { type: "slider_stepped", steps: ["minimal", "low", "medium", "high"], default: "default" }},
+            "@GPT-5-mini": { reasoning_effort: { type: "slider_stepped", steps: ["minimal", "low", "medium", "high"], default: "default" }},
+            "@GPT-5-nano": { reasoning_effort: { type: "slider_stepped", steps: ["minimal", "low", "medium", "high"], default: "default" }},
+            "@o1": { reasoning_effort: { type: "slider_stepped", steps: ["low", "medium", "high"], default: "default" }},
+            "@o3": { reasoning_effort: { type: "slider_stepped", steps: ["low", "medium", "high"], default: "default" }},
+            "@o3-mini": { reasoning_effort: { type: "slider_stepped", steps: ["low", "medium", "high"], default: "default" }},
+            "@o3-pro": { reasoning_effort: { type: "slider_stepped", steps: ["low", "medium", "high"], default: "default" }},
+            "@o4-mini": { reasoning_effort: { type: "slider_stepped", steps: ["low", "medium", "high"], default: "default" }},
+            "@Grok-3-Mini": { reasoning_effort: { type: "slider_stepped", steps: ["low", "high"], default: "default" }},
+            "@Tako": { specificity: { type: "slider", min: 0, max: 100, default: "default" }},
+            "@Linkup-Deep-Search": {
+                advanced_settings: {
+                    type: "advanced",
+                    fields: {
+                        domain_filter_mode: { type: "select", options: ["none", "Include", "Exclude"], default: "none" },
+                        include_domains: { type: "text", placeholder: "e.g. github.com", depends_on: "domain_filter_mode", depends_value: "Include" },
+                        exclude_domains: { type: "text", placeholder: "e.g. reddit.com", depends_on: "domain_filter_mode", depends_value: "Exclude" },
+                        prioritize_domains: { type: "text", placeholder: "e.g. stackoverflow.com" },
+                        from_date: { type: "text", placeholder: "YYYY-MM-DD" },
+                        to_date: { type: "text", placeholder: "YYYY-MM-DD" },
+                        include_images: { type: "checkbox", default: false },
+                        image_count: { type: "text", placeholder: "Number (e.g. 5)" }
+                    }
+                }
+            },
+            "@Linkup-Standard": {
+                thinking_budget: { type: "slider", min: 0, max: 32768, default: "default" },
+                advanced_settings: {
+                    type: "advanced",
+                    fields: {
+                        domain_filter_mode: { type: "select", options: ["none", "Include", "Exclude"], default: "none" },
+                        include_domains: { type: "text", placeholder: "e.g. github.com", depends_on: "domain_filter_mode", depends_value: "Include" },
+                        exclude_domains: { type: "text", placeholder: "e.g. reddit.com", depends_on: "domain_filter_mode", depends_value: "Exclude" },
+                        prioritize_domains: { type: "text", placeholder: "e.g. stackoverflow.com" },
+                        from_date: { type: "text", placeholder: "YYYY-MM-DD" },
+                        to_date: { type: "text", placeholder: "YYYY-MM-DD" },
+                        include_images: { type: "checkbox", default: false },
+                        image_count: { type: "text", placeholder: "Number (e.g. 5)" }
+                    }
+                }
+            },
+            "@Bagoodex-Web-Search": {
+                advanced_settings: {
+                    type: "advanced",
+                    fields: {
+                        domain_filter: { type: "text", placeholder: "e.g. legal-tools.org" },
+                        exclude_words: { type: "text", placeholder: "e.g. bemba" },
+                        search_images: { type: "checkbox", default: false },
+                        search_knowledge: { type: "checkbox", default: false },
+                        search_location: { type: "checkbox", default: false },
+                        search_videos: { type: "checkbox", default: false },
+                        search_weather: { type: "checkbox", default: false }
+                    }
+                }
+            }
+        };
+
+        /* ============================================
+           IMPROVED ACCORDION MANAGER CLASS
+           ============================================ */
+
+        class AccordionManager {
+            constructor(options = {}) {
+                this.options = {
+                    searchDebounceMs: 150,
+                    animationDuration: 300,
+                    ...options
+                };
+                
+                this.accordions = new Map();
+                this.expandedSections = new Map();
+                this.searchDebounceTimers = new Map();
+            }
+
+            createAccordion(containerId, data, config = {}) {
+                const accordion = {
+                    id: containerId,
+                    data: data,
+                    filteredData: data,
+                    isExpanded: false,
+                    selectedItem: null,
+                    searchTerm: '',
+                    callbacks: {
+                        onSelect: config.onSelect || (() => {}),
+                        onSearch: config.onSearch || (() => {}),
+                        onExpand: config.onExpand || (() => {}),
+                        onCollapse: config.onCollapse || (() => {})
+                    }
+                };
+
+                this.accordions.set(containerId, accordion);
+                this.initializeAccordionDOM(containerId);
+                return accordion;
+            }
+
+            initializeAccordionDOM(accordionId) {
+                const container = document.getElementById(accordionId);
+                if (!container) return;
+
+                // Build the accordion structure
+                container.innerHTML = `
+                    <div class="accordion-header" onclick="accordionManager.toggleAccordion('${accordionId}')">
+                        <div class="accordion-display">
+                            <span class="accordion-model-text">Select Model</span>
+                        </div>
+                        <div class="accordion-search-wrapper">
+                            <span class="accordion-search-icon">🔍</span>
+                            <input class="accordion-search-input" 
+                                   type="text"
+                                   placeholder="Search models..." 
+                                   onclick="event.stopPropagation()"
+                                   oninput="accordionManager.handleSearch('${accordionId}', this.value)" />
+                        </div>
+                        <span class="accordion-chevron">▼</span>
+                    </div>
+                    <div class="accordion-content-wrapper">
+                        <div class="accordion-content"></div>
+                    </div>
+                `;
+
+                // Set initial selected model if provided
+                const accordion = this.accordions.get(accordionId);
+                if (accordion && accordion.selectedItem) {
+                    this.updateSelectedDisplay(accordionId);
+                }
+            }
+
+            toggleAccordion(accordionId, forceState = null) {
+                const accordion = this.accordions.get(accordionId);
+                if (!accordion) return;
+
+                const container = document.getElementById(accordionId);
+                if (!container) return;
+
+                const wasExpanded = accordion.isExpanded;
+                accordion.isExpanded = forceState !== null ? forceState : !accordion.isExpanded;
+
+                // Close other accordions if opening this one
+                if (accordion.isExpanded && !wasExpanded) {
+                    this.accordions.forEach((other, otherId) => {
+                        if (otherId !== accordionId && other.isExpanded) {
+                            this.toggleAccordion(otherId, false);
+                        }
+                    });
+                }
+
+                // Update DOM state
+                if (accordion.isExpanded) {
+                    container.classList.add('expanded');
+                    
+                    // Focus search input
+                    setTimeout(() => {
+                        const searchInput = container.querySelector('.accordion-search-input');
+                        if (searchInput) {
+                            searchInput.focus();
+                        }
+                    }, 100);
+
+                    // Render content if needed
+                    const contentEl = container.querySelector('.accordion-content');
+                    if (contentEl && !contentEl.innerHTML.trim()) {
+                        this.renderAccordionContent(accordionId);
+                    }
+
+                    accordion.callbacks.onExpand(accordionId);
+                } else {
+                    container.classList.remove('expanded');
+                    
+                    // Clear search
+                    const searchInput = container.querySelector('.accordion-search-input');
+                    if (searchInput) {
+                        searchInput.value = '';
+                        accordion.searchTerm = '';
+                        accordion.filteredData = accordion.data;
+                    }
+
+                    accordion.callbacks.onCollapse(accordionId);
+                }
+            }
+
+            handleSearch(accordionId, searchTerm) {
+                // Clear existing debounce timer
+                if (this.searchDebounceTimers.has(accordionId)) {
+                    clearTimeout(this.searchDebounceTimers.get(accordionId));
+                }
+
+                // Set new debounce timer
+                const timer = setTimeout(() => {
+                    this.setSearchTerm(accordionId, searchTerm);
+                }, this.options.searchDebounceMs);
+
+                this.searchDebounceTimers.set(accordionId, timer);
+            }
+
+            setSearchTerm(accordionId, searchTerm) {
+                const accordion = this.accordions.get(accordionId);
+                if (!accordion) return;
+
+                accordion.searchTerm = searchTerm.toLowerCase();
+                accordion.filteredData = this.filterAccordionData(accordion.data, accordion.searchTerm);
+                
+                this.renderAccordionContent(accordionId);
+                accordion.callbacks.onSearch(searchTerm, accordion.filteredData);
+            }
+
+            renderAccordionContent(accordionId) {
+                const accordion = this.accordions.get(accordionId);
+                if (!accordion) return;
+
+                const container = document.getElementById(accordionId);
+                const contentEl = container?.querySelector('.accordion-content');
+                if (!contentEl) return;
+
+                let html = '';
+                let hasContent = false;
+```
+
+## FlagManager Class
+```js
+        class FlagManager {
+            constructor() {
+                this.modelFlags = {};
+            }
+
+            // Get flags for a specific model
+            getModelFlags(modelName) {
+                return MODEL_FLAGS[modelName] || {};
+            }
+
+            // Check if model has flags
+            hasFlags(modelName) {
+                return !!MODEL_FLAGS[modelName];
+            }
+
+            // Set flag value for a model instance
+            setFlag(modelName, flagName, value) {
+                if (!this.modelFlags[modelName]) {
+                    this.modelFlags[modelName] = {};
+                }
+                this.modelFlags[modelName][flagName] = value;
+            }
+
+            // Get flag value for a model instance
+            getFlag(modelName, flagName) {
+                return this.modelFlags[modelName]?.[flagName] || 'default';
+            }
+
+            // Generate flag string for API call
+            generateFlagString(modelName) {
+                const flags = this.modelFlags[modelName];
+                if (!flags) return '';
+
+                const flagParts = [];
+                
+                Object.entries(flags).forEach(([flagName, value]) => {
+                    if (flagName === 'advanced_settings' && typeof value === 'object') {
+                        // Handle advanced settings
+                        Object.entries(value).forEach(([subFlag, subValue]) => {
+                            if (subValue && subValue !== 'none' && subValue !== false) {
+                                if (typeof subValue === 'boolean') {
+                                    flagParts.push(`--${subFlag} true`);
+                                } else {
+                                    // Special handling for Linkup models
+                                    const isLinkup = modelName.includes('Linkup');
+                                    if (isLinkup) {
+                                        flagParts.push(`--${subFlag} ${subValue}`);
+                                    } else {
+                                        flagParts.push(`--${subFlag} "${subValue}"`);
+                                    }
+                                }
+                            }
+                        });
+                    } else if (value !== 'default') {
+                        flagParts.push(`--${flagName} ${value}`);
+                    }
+                });
+
+                return flagParts.length > 0 ? ' ' + flagParts.join(' ') : '';
+            }
+
+            // Reset flags for a model
+            resetFlags(modelName) {
+                delete this.modelFlags[modelName];
+            }
+
+            // Get all models with their current flag states
+            getAllModelStates() {
+                return { ...this.modelFlags };
+            }
+
+            // Set all model states (for import/export)
+            setAllModelStates(states) {
+                this.modelFlags = { ...states };
+            }
+        }
+
+        // Initialize global managers
+        const accordionManager = new AccordionManager();
+```
+
+## How it works
+- **Model-specific toggles** declare slider, stepped, checkbox, and advanced forms so each provider exposes the tuning options Poe accepts (thinking budget, reasoning effort, domain filters, etc.).
+- **Dynamic rendering** uses `updateFlagsVisibility` and `renderFlagControls` to reveal controls only when a selected model has entries in `MODEL_FLAGS`, keeping the UI lean by default.
+- **State persistence** records flag selections per model inside `this.modelFlags`, enabling export/import through `getAllModelStates` and `setAllModelStates`.
+- **Command string builder** (`generateFlagString`) converts the current selection into Poe-ready CLI flags, flattening advanced settings and quoting values where required.
+- **Reset helpers** let operators clear individual models or whole sessions when switching engines, preventing stale tuning parameters from leaking into new runs.

--- a/components/VG-Frankensteiner_v2_active_components/magic_box.md
+++ b/components/VG-Frankensteiner_v2_active_components/magic_box.md
@@ -1,0 +1,282 @@
+# Magic Box (Genie) Flow
+
+## Template
+```html
+<section class="mb-6 p-6 bg-gradient-to-r from-purple-50 to-blue-50 dark:from-purple-900/20 dark:to-blue-900/20 rounded-lg border border-purple-200 dark:border-purple-800">
+  <h3 class="font-semibold mb-4 text-purple-800 dark:text-purple-200 text-lg">⚡ Magic Box (Genie) - Universal Engine Designer</h3>
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+    <div class="lg:col-span-2 space-y-4">
+      <label class="block text-sm font-medium mb-2">Input Text or Description</label>
+      <textarea id="magicBoxInput" rows="8" class="w-full p-4 border rounded-lg" placeholder="Enter any text, problem, idea, or description..."></textarea>
+      <div class="flex items-center space-x-4">
+        <label class="block text-sm font-medium mb-2">File Attachment (Optional)
+          <input type="file" id="magicBoxFile" class="w-full text-sm" accept="*/*" />
+        </label>
+        <div class="flex-shrink-0">
+          <label class="block text-sm font-medium mb-2">Processing Model</label>
+          <div id="magicBoxModel" class="accordion-container w-64"></div>
+        </div>
+      </div>
+    </div>
+    <div class="space-y-4">
+      <label class="block text-sm font-medium mb-2">Bot Count</label>
+      <select id="botCountSelector" class="w-full p-2 border rounded">
+        <option value="1">1 Bot</option>
+        <option value="2">2 Bots</option>
+        <option value="3">3 Bots</option>
+        <option value="4" selected>4 Bots</option>
+        <option value="5">5 Bots</option>
+        <option value="6">6 Bots</option>
+        <option value="7">7 Bots</option>
+        <option value="8">8 Bots</option>
+        <option value="9">9 Bots</option>
+        <option value="10">10 Bots</option>
+      </select>
+      <button id="executeMagicBox" class="w-full px-6 py-3 bg-purple-600 text-white rounded-lg relative">
+        <span id="executeMagicBoxText">⚡ Generate Engine</span>
+        <div id="executeMagicBoxSpinner" class="hidden absolute inset-0 flex items-center justify-center">
+          <div class="animate-spin rounded-full h-5 w-5 border-2 border-white border-t-transparent"></div>
+        </div>
+      </button>
+      <div id="magicBoxFlags" class="hidden flag-container">
+        <div id="magicBoxFlagControls"></div>
+      </div>
+      <div id="magicBoxStatus" class="text-sm text-gray-600 dark:text-gray-400 min-h-[20px]"></div>
+    </div>
+  </div>
+</section>
+```
+
+## Execution Logic
+```js
+async function executeMagicBox() {
+  const input = document.getElementById('magicBoxInput').value;
+  const fileInput = document.getElementById('magicBoxFile');
+  const status = document.getElementById('magicBoxStatus');
+  const spinner = document.getElementById('executeMagicBoxSpinner');
+  const text = document.getElementById('executeMagicBoxText');
+  const botCountSelector = document.getElementById('botCountSelector');
+
+  if (!input.trim() && !fileInput.files[0]) {
+    status.textContent = 'Please provide text input or upload a file';
+    return;
+  }
+
+  spinner.classList.remove('hidden');
+  text.classList.add('invisible');
+  status.textContent = 'Processing with Magic Box...';
+
+  try {
+    updateProcessingLog('Starting Magic Box processing...');
+
+    let promptText = input.trim();
+    if (fileInput.files[0]) {
+      updateProcessingLog(`Reading file: ${fileInput.files[0].name}`);
+      const fileContent = await readFileContent(fileInput.files[0]);
+      promptText = promptText ? `${promptText}\n\nFile Content:\n${fileContent}` : fileContent;
+    }
+
+    const selectedModel = getSelectedModel('magicBoxModel');
+    const botCount = parseInt(botCountSelector.value);
+    const flagString = flagManager.generateFlagString(selectedModel);
+
+    const magicBoxPrompt = `ROLE: Anything Engine Architect
+SYSTEM: Anything Engine System Designer
+
+CRITICAL CANVAS CONTEXT:
+You are designing for Poe Canvas where window.Poe.sendUserMessage sends ALL previous messages in the conversation. This means Bot 3 receives Bot 1 and Bot 2's outputs whether wanted or not. Your prompts SHOULD handle this.
+
+CORE PHILOSOPHY:
+Your primary role is to populate the existing multi-stage framework of the Anything Engine by generating its three core operative components, based on the user's request:
+
+* The Keys: The Keys are the core intellectual tools for the engine. Each Key defines a unique perspective or method that will be used to operate upon a Subject. You are to generate a set of distinct Keys that intelligently reflect the user's core request.
+
+* The Subjects (from the Input bank): The Subjects are illustrative topics or pieces of raw content that the engine will process. They serve as the material for the Keys to act upon. You should generate a diverse set of Subjects to demonstrate the engine's capabilities within the universe defined by the user's mandate.
+
+* The Prompts: The Prompts are the operational instructions for each bot in the chain, defining a clear role and a step-by-step workflow. They should be written as flexible templates tailored to the user's mandate. A bot's prompt should be designed to use the provided Key and Subject as its primary operational material.
+
+The engine's power is derived from two key principles that you should build into your generated prompts:
+
+1. Task Specialization: Each bot in the sequence can dedicate its full processing capacity to its dedicated task. The chain can be designed with a mix of bot types, including both reasoning and web search models, to achieve a more focused and detailed output.
+2. Chained Contextualization: To manage the Poe Canvas environment, prompts (from the second bot onward) should be designed to treat the full output from previous steps as available background context. The prompt should then instruct the bot to perform its own unique, specialized task to actively build upon, refine, and improve the existing material, ensuring an incremental and value-adding workflow.
+
+YOUR TASK:
+Design a complete ${botCount}-bot engine from the user's input. Generate:
+1. 5-15 keys (Bank 1)
+2. 5-8 input samples (Bank 2)
+3. EXACTLY ${botCount} bot prompts (Bank 3)
+4. An engine description explaining the approach
+
+OUTPUT FORMAT (JSON ONLY):
+{
+  "engine_name": "short_descriptive_engine_name",
+  "engine_description": "2-3 paragraph description of the system",
+  "keys": [
+    {"id": 1, "name": "key_name", "method": "clear_operational_method"}
+  ],
+  "input": [
+    {"id": 1, "content": "sample_subject_content"}
+  ],
+  "prompts": [
+    {"id": 1, "bot_number": 1, "role": "role_name", "instructions": "complete_prompt_text"}
+  ]
+}
+
+REMEMBER:
+- Generate EXACTLY ${botCount} prompts.
+- Prompts from the second bot onward should handle the Canvas context accumulation as described in the philosophy.
+
+USER INPUT:
+${promptText}
+
+Generate the complete engine now as valid JSON only.`;
+
+    updateProcessingLog(`Sending to ${selectedModel}...`);
+    await window.Poe.sendUserMessage(`${selectedModel} ${magicBoxPrompt}${flagString}`, {
+      handler: 'magic-box-handler',
+      stream: true,
+      openChat: false,
+    });
+  } catch (error) {
+    console.error('Magic Box error:', error);
+    status.textContent = `Error: ${error.message}`;
+    updateProcessingLog(`Error: ${error.message}`);
+  } finally {
+    spinner.classList.add('hidden');
+    text.classList.remove('invisible');
+  }
+}
+
+function handleMagicBoxResponse(result) {
+  const status = document.getElementById('magicBoxStatus');
+
+  if (result.responses && result.responses.length > 0) {
+    const response = result.responses[0];
+
+    if (response.status === 'error') {
+      status.textContent = 'Error occurred during processing';
+      updateProcessingLog(`Error: ${response.statusText || 'Unknown error'}`);
+    } else if (response.status === 'incomplete') {
+      status.textContent = 'Generating transformation engine...';
+      if (response.content && response.content.trim()) {
+        activeResponseIds.magicbox_streaming = updateProcessingLog({
+          title: 'Magic Box streaming response',
+          content: response.content,
+        }, true, activeResponseIds.magicbox_streaming);
+      }
+    } else if (response.status === 'complete') {
+      status.textContent = 'Magic Box processing complete!';
+      updateProcessingLog('Magic Box completed successfully');
+      updateProcessingLog({ title: 'Magic Box complete response', content: response.content }, true);
+      delete activeResponseIds.magicbox_streaming;
+
+      try {
+        const content = response.content.trim();
+        const jsonMatch = content.match(/```json\s*([\s\S]*?)\s*```/) ||
+                         content.match(/```\s*([\s\S]*?)\s*```/) ||
+                         content.match(/\{[\s\S]*\}/);
+
+        if (!jsonMatch) throw new Error('Could not extract JSON from response');
+
+        const jsonString = jsonMatch[1] || jsonMatch[0];
+        const parsedData = JSON.parse(jsonString);
+
+        updateProcessingLog({
+          title: 'Magic Box parsed JSON structure',
+          content: JSON.stringify(parsedData, null, 2),
+        }, true);
+
+        bankData.engineName = parsedData.engine_name || 'UnnamedEngine';
+        updateProcessingLog(`Engine name: ${bankData.engineName}`);
+
+        if (parsedData.keys) {
+          bankData.keys = parsedData.keys;
+          updateBankStatus('keysStatus', `Loaded ${parsedData.keys.length} keys`);
+        }
+        if (parsedData.input) {
+          bankData.input = parsedData.input;
+          updateBankStatus('inputStatus', `Loaded ${parsedData.input.length} inputs`);
+        }
+        if (parsedData.prompts) {
+          bankData.prompts = parsedData.prompts;
+          updateBankStatus('promptsStatus', `Loaded ${parsedData.prompts.length} prompts`);
+          populateBotsFromPrompts();
+        }
+
+        updatePreview(parsedData.engine_description, bankData.keys, bankData.input, bankData.prompts);
+        enableRandomButtons();
+      } catch (parseError) {
+        console.error('Magic Box parsing error:', parseError);
+        status.textContent = 'Could not parse engine structure';
+        updateProcessingLog(`Parsing error: ${parseError.message}`);
+      }
+    }
+  }
+}
+
+window.Poe.registerHandler('magic-box-handler', result => handleMagicBoxResponse(result));
+```
+
+## Architect Prompt Blueprint
+The template literal above resolves to the following operator-facing brief when rendered (placeholders wrapped in `{{ }}` indicate runtime substitutions):
+
+```text
+ROLE: Anything Engine Architect
+SYSTEM: Anything Engine System Designer
+
+CRITICAL CANVAS CONTEXT:
+You are designing for Poe Canvas where window.Poe.sendUserMessage sends ALL previous messages in the conversation. This means Bot 3 receives Bot 1 and Bot 2's outputs whether wanted or not. Your prompts SHOULD handle this.
+
+CORE PHILOSOPHY:
+Your primary role is to populate the existing multi-stage framework of the Anything Engine by generating its three core operative components, based on the user's request:
+
+* The Keys: The Keys are the core intellectual tools for the engine. Each Key defines a unique perspective or method that will be used to operate upon a Subject. You are to generate a set of distinct Keys that intelligently reflect the user's core request.
+
+* The Subjects (from the Input bank): The Subjects are illustrative topics or pieces of raw content that the engine will process. They serve as the material for the Keys to act upon. You should generate a diverse set of Subjects to demonstrate the engine's capabilities within the universe defined by the user's mandate.
+
+* The Prompts: The Prompts are the operational instructions for each bot in the chain, defining a clear role and a step-by-step workflow. They should be written as flexible templates tailored to the user's mandate. A bot's prompt should be designed to use the provided Key and Subject as its primary operational material.
+
+The engine's power is derived from two key principles that you should build into your generated prompts:
+
+1. Task Specialization: Each bot in the sequence can dedicate its full processing capacity to its dedicated task. The chain can be designed with a mix of bot types, including both reasoning and web search models, to achieve a more focused and detailed output.
+2. Chained Contextualization: To manage the Poe Canvas environment, prompts (from the second bot onward) should be designed to treat the full output from previous steps as available background context. The prompt should then instruct the bot to perform its own unique, specialized task to actively build upon, refine, and improve the existing material, ensuring an incremental and value-adding workflow.
+
+YOUR TASK:
+Design a complete {{BOT_COUNT}}-bot engine from the user's input. Generate:
+1. 5-15 keys (Bank 1)
+2. 5-8 input samples (Bank 2)
+3. EXACTLY {{BOT_COUNT}} bot prompts (Bank 3)
+4. An engine description explaining the approach
+
+OUTPUT FORMAT (JSON ONLY):
+{
+  "engine_name": "short_descriptive_engine_name",
+  "engine_description": "2-3 paragraph description of the system",
+  "keys": [
+    {"id": 1, "name": "key_name", "method": "clear_operational_method"}
+  ],
+  "input": [
+    {"id": 1, "content": "sample_subject_content"}
+  ],
+  "prompts": [
+    {"id": 1, "bot_number": 1, "role": "role_name", "instructions": "complete_prompt_text"}
+  ]
+}
+
+REMEMBER:
+- Generate EXACTLY {{BOT_COUNT}} prompts.
+- Prompts from the second bot onward should handle the Canvas context accumulation as described in the philosophy.
+
+USER INPUT:
+{{PROMPT_TEXT}}
+
+Generate the complete engine now as valid JSON only.
+```
+
+*Dynamic slots:* `{{BOT_COUNT}}` mirrors the selected bot count, `{{PROMPT_TEXT}}` contains the staged Magic Box description plus any attached file contents, and the rendered prompt inherits any flag string appended to the model call.
+
+## How it works
+- **Guided inputs** collect a freeform brief, optional file, chosen model, and bot-count target, revealing additional tuning flags when the selected model supports them.
+- **Execution button state** swaps text for a spinner while Magic Box runs, with status messages and processing log entries so operators know exactly what the Genie is doing.
+- **Streaming handler** keeps the status panel and log updated in real time, then parses the returned JSON to hydrate the Keys/Input/Prompt banks and preview cards.
+- **Bank synchronisation** stores the parsed engine into `bankData`, updates bank status chips, and triggers helper utilities (`populateBotsFromPrompts`, `enableRandomButtons`) for the execution page.

--- a/components/VG-LegalApp_v5_active_components/README.md
+++ b/components/VG-LegalApp_v5_active_components/README.md
@@ -1,0 +1,19 @@
+# DRBanger Enhanced Legal Research System — Component Index
+
+The **VG-LegalApp_v5_active** canvas is a manual, six-bot workflow for legal research refinement. Users curate their source material, pair it with SST (Structured Strategic Technique) capsules, then drive the chain manually bot-by-bot while capturing state, logs, and generated improvements. This directory extracts the reusable building blocks so both builders and operators can understand what powers the experience.
+
+## Experience Map
+- **Input Configuration Tab** – Upload JSON databases, craft legal text + SST payloads, and stage prompts/injection notes before running any bots.
+- **Execution & Results Tab** – Orchestrate six specialised bots (SST applicator → adversarial reviewer → international-law validator → ICC synthesiser → publication QA → SST improver) with mirrored controls and live status feedback.
+- **Global Utilities** – Persistent floating "Next Bot" launcher, activity log with streaming updates, custom-instruction injectors per bot, and state save/load pipeline for migrating work between sessions.
+
+## Key Modules Extracted
+1. **Input Configuration Layout** – `input_configuration.md` captures the Tailwind layout for the File Upload Centre, legal/SST editors, and manual SST selector.
+2. **Accordion Model Selector** – `model_selection.md` documents the searchable accordion used to pick a bot model from an extensive catalogue, including keyboard navigation and auto-collapse logic.
+3. **Workflow Runner** – `workflow_engine.md` shows how six bot prompts are assembled, validated, and sent to Poe while synchronising UI state, timeouts, and floating-button progress.
+4. **Prompt Templates** – `prompts.md` transcribes every bot mandate so operators can see the exact roles and insertion points feeding the chain.
+5. **State Management Suite** – `state_management.md` details how the app serialises inputs, outputs, injected instructions, and workflow metadata for clipboard/file storage with validation safeguards.
+
+Each module file contains two parts: the lifted template/code and a plain-language explanation so operators know what the interface affords and developers can repurpose the logic.
+
+> ❗ **Source of truth**: `HTML Apps/Law Thesis/VG-LegalApp_v5_active.html` remains untouched. This folder only mirrors the relevant structures for documentation and reuse.

--- a/components/VG-LegalApp_v5_active_components/input_configuration.md
+++ b/components/VG-LegalApp_v5_active_components/input_configuration.md
@@ -1,0 +1,105 @@
+# Input Configuration Layout
+
+## Template
+```html
+<div id="tab-content-input" class="tab-content active">
+  <div class="bg-gray-50 dark:bg-gray-800 rounded-lg p-6 mb-6">
+    <div class="flex justify-between items-center mb-4">
+      <h2 class="text-xl font-semibold">📝 Input Configuration</h2>
+      <div class="flex space-x-2 text-sm">
+        <button id="saveStateInput" class="p-2" title="Copy State to Clipboard">💾</button>
+        <button id="downloadStateInput" class="p-2" title="Download State as File">📥</button>
+        <button id="loadStateInput" class="p-2" title="Load State from File">📁</button>
+        <button id="importStateInput" class="p-2" title="Import State from Clipboard">📋</button>
+        <button id="downloadFlow" class="p-2" title="Download Responses">📄</button>
+      </div>
+    </div>
+
+    <section class="mb-6 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
+      <h3 class="font-semibold mb-3 text-blue-800 dark:text-blue-200">📁 File Upload Center</h3>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <label class="text-sm space-y-2 text-center">
+          <span class="block font-medium">Legal Texts Database</span>
+          <input type="file" id="legalTextFile" accept=".json" class="w-full text-sm" />
+          <span class="block text-xs text-gray-500">JSON array of legal texts</span>
+        </label>
+        <label class="text-sm space-y-2 text-center">
+          <span class="block font-medium">SST Techniques Database</span>
+          <input type="file" id="sstDatabaseFile" accept=".json" class="w-full text-sm" />
+          <span class="block text-xs text-gray-500">Hierarchical SST database</span>
+        </label>
+        <label class="text-sm space-y-2 text-center">
+          <span class="block font-medium">Bot Prompts Database</span>
+          <input type="file" id="botPromptsFile" accept=".json" class="w-full text-sm" />
+          <span class="block text-xs text-gray-500">Bot prompt templates</span>
+        </label>
+      </div>
+      <div class="mt-3 grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+        <span id="legalTextDatabaseStatus">No database loaded</span>
+        <span id="sstDatabaseStatus">No database loaded</span>
+        <span id="botPromptsDatabaseStatus">No database loaded</span>
+      </div>
+    </section>
+
+    <section class="mb-4">
+      <label class="block text-sm font-medium mb-2">Legal Text (e.g., ICC Article 17)</label>
+      <div class="relative">
+        <textarea id="legalText" rows="4" class="w-full p-3 border rounded-lg"></textarea>
+        <div class="absolute top-2 right-2 flex space-x-1">
+          <button id="copyLegalText" class="p-1" title="Copy to Clipboard">📋</button>
+          <button id="feedLegalText" class="p-1" title="Feed to Preview">📤</button>
+        </div>
+      </div>
+      <div class="mt-3 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
+        <h4 class="font-semibold mb-2 text-blue-800 dark:text-blue-200 text-sm">📖 Legal Text Database</h4>
+        <div class="flex items-center space-x-3 mt-2 text-sm">
+          <div class="flex items-center space-x-2">
+            <label class="text-gray-600 dark:text-gray-400">Find by ID:</label>
+            <input type="text" id="legalTextSearch" class="w-20 px-2 py-1 border rounded" placeholder="ID" />
+            <button id="loadLegalTextById" class="px-3 py-1 bg-blue-600 text-white rounded" disabled>Load</button>
+          </div>
+          <button id="randomizeLegalText" class="px-3 py-1 bg-green-600 text-white rounded" disabled>🎲 Random</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-4">
+      <label class="block text-sm font-medium mb-2">SST Technique</label>
+      <div class="relative">
+        <textarea id="sstCapsule" rows="3" class="w-full p-3 border rounded-lg"></textarea>
+        <div class="absolute top-2 right-2 flex space-x-1">
+          <button id="copySSTCapsule" class="p-1" title="Copy to Clipboard">📋</button>
+          <button id="feedSSTCapsule" class="p-1" title="Feed to Preview">📤</button>
+        </div>
+      </div>
+      <div class="mt-4 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
+        <h3 class="font-semibold mb-3 text-blue-800 dark:text-blue-200">🎯 Manual SST Selection</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-3">
+          <label class="block text-sm font-medium">Domain
+            <select id="sstDomainSelect" class="w-full p-2 border rounded">
+              <option value="">Select a domain...</option>
+            </select>
+          </label>
+          <label class="block text-sm font-medium">Technique
+            <select id="sstTechniqueSelect" class="w-full p-2 border rounded" disabled>
+              <option value="">Select a technique...</option>
+            </select>
+          </label>
+        </div>
+        <div class="flex flex-wrap gap-2 text-sm">
+          <button id="loadTechniqueCapsule" class="px-3 py-1 bg-blue-600 text-white rounded" disabled>📥 Load Technique Capsule</button>
+          <button id="previewTechnique" class="px-3 py-1 bg-purple-600 text-white rounded" disabled>👁️ Preview Technique</button>
+          <button id="sampleSSTBtn" class="px-4 py-2 bg-gray-200 dark:bg-gray-600 text-sm rounded">🎲 Sample Random SST</button>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+```
+
+## How it works
+- **State-first controls** keep clipboard, download, and import buttons visible so researchers can snapshot the entire session before running any analyses.
+- **File Upload Centre** ingests three optional JSON payloads (legal texts, SST techniques, bot prompts) and displays their load status, making it obvious when the internal libraries are ready.
+- **Legal Text authoring** combines freeform drafting with quick database recall: users can load specific IDs, randomise a sample, copy to clipboard, or stage the content for downstream preview tools.
+- **SST Technique authoring** mirrors the legal text editor, but adds cascading dropdowns for selecting pre-built SST capsules and helper buttons for previewing or sampling techniques.
+- **Assistive buttons** remain disabled until supporting data is loaded, preventing broken flows while guiding users through the recommended preparation order.

--- a/components/VG-LegalApp_v5_active_components/model_selection.md
+++ b/components/VG-LegalApp_v5_active_components/model_selection.md
@@ -1,0 +1,629 @@
+# Accordion Model Selector
+
+## Model Catalogue Data
+```js
+        const multimodalModels = {
+            "Favorites": [
+                "@GPT-5",
+                "@GPT-4.1",
+                "@o3-pro",
+                "@o1",
+                "@Gemini-2.5-Pro",
+                "@Claude-Opus-4-Reasoning",
+                "@Claude-Opus-4.1",
+                "@Claude-Opus-4-Search",
+                "@Claude-Sonnet-4-Search",
+                "@Grok-4",
+                "@Mistral-Large-2"
+            ],
+            "Web Search": [
+                "@Claude-Opus-4-Search",
+                "@Claude-Sonnet-4-Search",
+                "@Gemini-2.5-Flash",
+                "@Gemini-2.5-Pro",
+                "@Grok-4",
+                "@Perplexity-Sonar",
+                "@Perplexity-Sonar-Rsn-Pro",
+                "@GPT-4o-Search",
+                "@Linkup-Deep-Search"   
+            ],
+            "GPT": {
+                "GPT-5 Series": [
+                    "@GPT-5-Chat",
+                    "@GPT-5",
+                    "@GPT-5-mini",
+                    "@GPT-5-nano"
+                ],
+                "GPT-4 Series": [
+                    "@GPT-4.1",
+                    "@GPT-4o-Search",
+                    "@GPT-4-Classic",
+                    "@GPT-4-Classic-0314",
+                    "@GPT-4-Turbo",
+                    "@GPT-4.1-mini",
+                    "@GPT-4.1-nano",
+                    "@GPT-4o",
+                    "@GPT-4o-mini",
+                    "@GPT-4o-mini-Search",
+                    "@GPT-4o-Aug"
+                ],
+                "GPT-3.5 Series": [
+                    "@GPT-3.5-Turbo",
+                    "@GPT-3.5-Turbo-Instruct",
+                    "@GPT-3.5-Turbo-Raw"
+                ],
+                "o-Series (Reasoning)": [
+                    "@o1",
+                    "@o3",
+                    "@o3-pro",
+                    "@o1-mini",
+                    "@o3-mini",
+                    "@o3-mini-high",
+                    "@o4-mini",
+                    "@o3-Pro"
+                ]
+            },
+            "GPT - Open Weight": {
+                "120B Parameter Models": [
+                    "@GPT-OSS-120B-T",
+                    "@GPT-OSS-120B",
+                    "@GPT-OSS-120B-CS",
+                    "@OpenAI-GPT-OSS-120B"
+                ],
+                "20B Parameter Models": [
+                    "@GPT-OSS-20B-T",
+                    "@GPT-OSS-20B",
+                    "@OpenAI-GPT-OSS-20B"
+                ]
+            },
+            "Google": {
+                "Gemini 2.5 Series": [
+                    "@Gemini-2.5-Pro",
+                    "@Gemini-2.5-Flash",
+                    "@Gemini-2.5-Flash-Lite",
+                    "@Gemini-2.5-Flash-Image"
+                ],
+                "Gemini 2.0 Series": [
+                    "@Gemini-2.0-Flash",
+                    "@Gemini-2.0-Flash-Lite",
+                    "@Gemini-2.0-Flash-Preview"
+                ],
+                "Gemini 1.5 Series": [
+                    "@Gemini-1.5-Pro",
+                    "@Gemini-1.5-Pro-Search",
+                    "@Gemini-1.5-Flash",
+                    "@Gemini-1.5-Flash-Search"
+                ],
+                "Gemma Series": [
+                    "@Gemma-3-27B",
+                    "@Gemma-2-27b-T"
+                ]
+            },
+            "Claude": {
+                "Opus Series": [
+                    "@Claude-Opus-4.1",
+                    "@Claude-Opus-4",
+                    "@Claude-Opus-4-Reasoning",
+                    "@Claude-Opus-4-Search",
+                    "@Claude-Opus-3"
+                ],
+                "Sonnet Series": [
+                    "@Claude-Sonnet-4",
+                    "@Claude-Sonnet-4-Reasoning",
+                    "@Claude-Sonnet-4-Search",
+                    "@Claude-Sonnet-3.5",
+                    "@Claude-Sonnet-3.5-June",
+                    "@Claude-Sonnet-3.5-Search",
+                    "@Claude-Sonnet-3.7",
+                    "@Claude-Sonnet-3.7-Reasoning",
+                    "@Claude-Sonnet-3.7-Search"
+                ],
+                "Haiku Series": [
+                    "@Claude-Haiku-3.5",
+                    "@Claude-Haiku-3",
+                    "@Claude-Haiku-3.5-Search"
+                ]
+            },
+            "Grok": [
+                "@Grok-4",
+                "@Grok-3",
+                "@Grok-3-Mini",
+                "@Grok-Code-Fast-1",
+                "@Grok-2"
+            ],
+            "Llama 4": [
+                "@Llama-4-Scout-B10",
+                "@Llama-4-Maverick",
+                "@Llama-4-Scout-T",
+                "@Llama-4-Scout-CS",
+                "@Llama-4-Scout",
+                "@Llama-4-Maverick-T",
+                "@Llama-4-Maverick-B10"
+            ],
+            "Llama 3.X": {
+                "The Behemoths (405B)": [
+                    "@Llama-3.1-405B",
+                    "@Llama-3.1-405B-T",
+                    "@Llama-3.1-405B-FW",
+                    "@Llama-3.1-405B-FP16"
+                ],
+                "The Curated 70B Fleet": [
+                    "@Llama-3-70b-Groq",
+                    "@Llama-3.3-70B",
+                    "@Llama-3.1-Nemotron",
+                    "@Llama-3.3-70B-DI",
+                    "@Llama-3.3-70B-CS",
+                    "@Llama-3.3-70B-Vers",
+                    "@Llama-3-70B-FP16",
+                    "@Llama-3-70B-T",
+                    "@Llama-3.1-70B",
+                    "@Llama-3.1-70B-FP16",
+                    "@Llama-3.1-70B-FW",
+                    "@Llama-3.1-70B-T",
+                    "@Llama-3.3-70B-FW",
+                    "@Llama-3.3-70B-N"
+                ],
+                "The 8B Fleet": [
+                    "@Llama-3-8B-T",
+                    "@Llama-3-8b-Groq",
+                    "@Llama-3.1-8B",
+                    "@Llama-3.1-8B-CS",
+                    "@Llama-3.1-8B-DI",
+                    "@Llama-3.1-8B-FP16",
+                    "@Llama-3.1-8B-FW",
+                    "@Llama-3.1-8B-T-128k"
+                ]
+            },
+            "Qwen (235B+)": {
+                "480B": [
+                    "@Qwen3-480B-Coder-CS",
+                    "@Qwen3-Coder-480B-T",
+                    "@Qwen3-Coder-480B-N"
+                ],
+                "235B": [
+                    "@Qwen-3-235B-2507-T",
+                    "@Qwen3-235B-2507-FW",
+                    "@Qwen3-235B-2507-CS",
+                    "@Qwen3-235B-A22B",
+                    "@Qwen3-235B-A22B-DI",
+                    "@Qwen3-235B-A22B-N",
+                    "@Qwen3-235B-Think-CS"
+                ],
+                "72B": [
+                    "@Qwen-72B-T",
+                    "@Qwen2-72B-Instruct-T",
+                    "@Qwen2.5-VL-72B-T",
+                    "@Qwen-2.5-72B-T"
+                ],
+                "30–32B": [
+                    "@Qwen3-30B-A3B-Instruct",
+                    "@Qwen2.5-Coder-32B",
+                    "@Qwen2.5-Coder-32B-T",
+                    "@Qwen3-32B-CS",
+                    "@Qwen3-Coder-30B-A3B"
+                ],
+                "≤32B & VL": [
+                    "@Qwen-2.5-7B-T",
+                    "@Qwen-2.5-VL-32b"
+                ],
+                "General": [
+                    "@Qwen3-Coder"
+                ]
+            },
+            "DeepSeek": {
+                "R1 Series (Reasoning)": [
+                    "@DeepSeek-R1",
+                    "@DeepSeek-R1-FW",
+                    "@DeepSeek-R1-DI",
+                    "@DeepSeek-R1-N",
+                    "@DeepSeek-R1-Distill",
+                    "@DeepSeek-R1-Turbo-DI"
+                ],
+                "V3 Series (Foundation)": [
+                    "@DeepSeek-V3.1",
+                    "@DeepSeek-V3.1-N",
+                    "@Deepseek-V3-FW",
+                    "@DeepSeek-V3",
+                    "@DeepSeek-V3-DI",
+                    "@DeepSeek-V3-Turbo-DI"
+                ],
+                "Specialized & Hybrids": [
+                    "@DeepSeek-Prover-V2",
+                    "@DeepClaude"
+                ]
+            },
+            "Mistral": {
+                "Large Series": [
+                    "@Mistral-Large-2"
+                ],
+                "Medium Series": [
+                    "@Mistral-Medium-3",
+                    "@Mistral-Medium",
+                    "@Magistral-Medium-2506-Thinking"
+                ],
+                "Small Series (Vision-Enabled)": [
+                    "@Mistral-Small-3.2",
+                    "@Mistral-Small-3.1",
+                    "@Mistral-Small-3",
+                    "@Mistral-7B-v0.3-DI",
+                    "@Mistral-7B-v0.3-T"
+                ],
+                "Specialized & MoE Models": [
+                    "@Mistral-NeMo",
+                    "@Mixtral8x22b-Inst-FW"
+                ]
+            },
+            "Perplexity": [
+                "@Perplexity-R1-1776",
+                "@Perplexity-Sonar",
+                "@Perplexity-Sonar-Pro",
+                "@Perplexity-Sonar-Rsn",
+                "@Perplexity-Sonar-Rsn-Pro"
+            ],
+            "Wildcards (A-K)": [
+                "@Aya-Expanse-32B",
+                "@Aya-Vision",
+                "@Command-R",
+                "@Command-R-Plus",
+                "@GLM-4.5",
+                "@GLM-4.5-Air",
+                "@GLM-4.5-Air-T",
+                "@GLM-4.5-FW",
+                "@Inception-Mercury",
+                "@Inception-Mercury-Coder",
+                "@Bagoodex-Web-Search",
+                "@Hermes-3-70B",
+                "@Kimi-K2",
+                "@Kimi-K2-Instruct",
+                "@Kimi-K2-T"
+            ],
+            "Wildcards (L-Z)": [
+                "@Linkup-Standard",
+                "@MiniMax-M1",
+                "@Phi-4-DI",
+                "@QwQ-32B-B10",
+                "@QwQ-32B-Preview-T",
+                "@QwQ-32B-T",
+                "@Reka-Core",
+                "@Reka-Flash",
+                "@Reka-Research",
+                "@Tako",
+                "@Solar-Pro-2"
+            ]
+        };
+
+        // State for model selections
+        let selectedBotModels = ['', '', '', '', '', ''];
+
+        // ===== ACCORDION MODEL SELECTOR CLASS =====
+        class AccordionModelSelector {
+            constructor(botId) {
+                this.botId = botId;
+                this.selectedModel = '';
+                this.container = document.getElementById(`accordion-root-${botId}`);
+                this.selectorContainer = document.getElementById(`selector-container-${botId}`);
+                this.searchInput = document.getElementById(`model-search-${botId}`);
+                this.clearBtn = document.getElementById(`clear-btn-${botId}`);
+                this.isCollapsed = true;
+                this.searchTerm = '';
+                this.currentData = multimodalModels;
+                this.highlightedIndex = -1;
+                this.init();
+            }
+
+            init() {
+                this.render();
+                this.attachEventListeners();
+                this.selectorContainer.classList.add('collapsed');
+                this.bindSearchInput();
+            }
+
+            bindSearchInput() {
+```
+
+## AccordionModelSelector Class
+```js
+                const input = this.searchInput;
+                if (!input) return;
+                const stop = (e) => { e.stopPropagation(); e.stopImmediatePropagation(); };
+                input.addEventListener('click', stop);
+                input.addEventListener('mousedown', stop);
+                input.addEventListener('pointerdown', stop);
+                input.addEventListener('touchstart', (e) => { stop(e); input.focus(); }, { passive: false });
+
+                input.addEventListener('input', (e) => {
+                    const currentValue = (e.target.value || '').trim();
+                    this.searchTerm = currentValue;
+                    
+                    // If user is typing something different from selected model, auto-clear selection
+                    if (this.selectedModel && currentValue !== this.selectedModel && currentValue !== '') {
+                        this.autoClearSelection();
+                    }
+                    
+                    this.applySearch();
+                    // Auto-expand to show matches when typing
+                    if (this.isCollapsed && this.searchTerm) this.expand();
+                    // Reset keyboard navigation when search changes
+                    this.highlightedIndex = -1;
+                    this.updateHighlight();
+                });
+                
+                input.addEventListener('keydown', (e) => {
+                    if (e.key === 'Escape') {
+                        e.preventDefault();
+                        input.value = '';
+                        this.searchTerm = '';
+                        this.applySearch();
+                        this.highlightedIndex = -1;
+                        this.updateHighlight();
+                    } else if (e.key === 'ArrowDown') {
+                        e.preventDefault();
+                        if (this.isCollapsed) this.expand();
+                        this.navigateDown();
+                    } else if (e.key === 'ArrowUp') {
+                        e.preventDefault();
+                        if (this.isCollapsed) this.expand();
+                        this.navigateUp();
+                    } else if (e.key === 'Enter') {
+                        e.preventDefault();
+                        if (this.highlightedIndex >= 0) {
+                            this.selectHighlightedModel();
+                        }
+                    }
+                });
+                
+                // Add focus behavior to make it clear the input is editable
+                input.addEventListener('focus', (e) => {
+                    if (this.selectedModel) {
+                        input.select(); // Select all text to make editing easier
+                    }
+                    if (this.isCollapsed) this.expand();
+                });
+            }
+
+            sanitizeId(str) {
+                return str.replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase();
+            }
+
+            render(data = this.currentData) {
+                this.currentData = data;
+                let html = '';
+                
+                Object.entries(data).forEach(([provider, pdata]) => {
+                    const providerId = this.sanitizeId(provider);
+                    const modelCount = this.countModels(pdata);
+                    
+                    html += `
+                        <div class="accordion-item">
+                            <div class="accordion-header" data-provider="${providerId}">
+                                <span class="accordion-title">${provider}</span>
+                                <span style="display: flex; align-items: center; gap: 6px;">
+                                    <span class="model-count">${modelCount}</span>
+                                    <svg class="accordion-icon" fill="currentColor" viewBox="0 0 20 20">
+                                        <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+                                    </svg>
+                                </span>
+                            </div>
+                            <div class="accordion-content" id="content-${providerId}-${this.botId}">
+                                ${this.renderSeries(pdata, providerId)}
+                            </div>
+                        </div>
+                    `;
+                });
+                
+                this.container.innerHTML = html;
+
+                // Auto-expand when searching so results are visible
+                if (this.searchTerm) {
+                    this.container.querySelectorAll('.accordion-header').forEach(h => h.classList.add('active'));
+                    this.container.querySelectorAll('.accordion-content').forEach(c => c.classList.add('active'));
+                    this.container.querySelectorAll('.series-header').forEach(h => h.classList.add('active'));
+                    this.container.querySelectorAll('.series-content').forEach(c => c.classList.add('active'));
+                }
+
+                // Re-apply selected highlight and reflect value
+                if (this.selectedModel) {
+                    const sel = this.container.querySelector(`.model-item[data-model="${CSS.escape(this.selectedModel)}"]`);
+                    if (sel) sel.classList.add('selected');
+                    if (this.searchInput) this.searchInput.value = this.selectedModel;
+                } else {
+                    if (this.searchInput && !this.searchTerm) {
+                        this.searchInput.value = '';
+                        this.searchInput.placeholder = 'Search or select model...';
+                    }
+                }
+            }
+
+            renderSeries(data, providerId) {
+                let html = '';
+                
+                if (Array.isArray(data)) {
+                    const list = this.sortModels(data);
+                    list.forEach(model => {
+                        const modelId = this.sanitizeId(model);
+                        html += `
+                            <div class="model-item" data-model="${model}" data-model-id="${modelId}">
+                                ${model}
+                            </div>
+                        `;
+                    });
+                } else {
+                    Object.entries(data).forEach(([series, models]) => {
+                        const seriesId = this.sanitizeId(series);
+                        
+                        if (models.length === 0) {
+                            html += `
+                                <div class="series-item">
+                                    <div class="series-header" style="color: var(--text-secondary); font-style: italic;">
+                                        <span>${series} (empty)</span>
+                                    </div>
+                                </div>
+                            `;
+                        } else {
+                            const list = this.sortModels(models);
+                            html += `
+                                <div class="series-item">
+                                    <div class="series-header" data-series="${seriesId}">
+                                        <span>${series}</span>
+                                        <span style="display: flex; align-items: center; gap: 6px;">
+                                            <span class="model-count">${list.length}</span>
+                                            <svg class="accordion-icon" style="width: 14px; height: 14px;" fill="currentColor" viewBox="0 0 20 20">
+                                                <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+                                            </svg>
+                                        </span>
+                                    </div>
+                                    <div class="series-content" id="series-${seriesId}-${this.botId}">
+                                        ${list.map(model => {
+                                            const modelId = this.sanitizeId(model);
+                                            return `
+                                                <div class="model-item" data-model="${model}" data-model-id="${modelId}">
+                                                    ${model}
+                                                </div>
+                                            `;
+                                        }).join('')}
+                                    </div>
+                                </div>
+                            `;
+                        }
+                    });
+                }
+                
+                return html;
+            }
+
+            normalizeName(name) {
+                return (name || '').replace(/^@/, '').toLowerCase();
+            }
+
+            sortModels(models) {
+                let list = Array.from(models);
+                if (!this.searchTerm) {
+                    return list.sort((a, b) => this.normalizeName(a).localeCompare(this.normalizeName(b)));
+                }
+                const term = this.searchTerm.toLowerCase();
+                const starts = [];
+                const contains = [];
+                list.forEach(m => {
+                    const n = this.normalizeName(m);
+                    if (n.startsWith(term)) starts.push(m);
+                    else if (n.includes(term)) contains.push(m);
+                });
+                starts.sort((a, b) => this.normalizeName(a).localeCompare(this.normalizeName(b)));
+                contains.sort((a, b) => this.normalizeName(a).localeCompare(this.normalizeName(b)));
+                return [...starts, ...contains];
+            }
+
+            getFilteredData() {
+                const term = this.searchTerm.toLowerCase();
+                if (!term) return multimodalModels;
+                const out = {};
+                Object.entries(multimodalModels).forEach(([provider, pdata]) => {
+                    if (Array.isArray(pdata)) {
+                        const filtered = pdata.filter(m => this.normalizeName(m).includes(term));
+                        if (filtered.length) out[provider] = filtered;
+                    } else {
+                        const seriesOut = {};
+                        Object.entries(pdata).forEach(([series, models]) => {
+                            const filtered = models.filter(m => this.normalizeName(m).includes(term));
+                            if (filtered.length) seriesOut[series] = filtered;
+                        });
+                        if (Object.keys(seriesOut).length) out[provider] = seriesOut;
+                    }
+                });
+                return out;
+            }
+
+            applySearch() {
+                const data = this.getFilteredData();
+                this.render(data);
+            }
+
+            countModels(data) {
+                if (Array.isArray(data)) {
+                    return data.length;
+                }
+                
+                let count = 0;
+                Object.values(data).forEach(models => {
+                    if (Array.isArray(models)) {
+                        count += models.length;
+                    } else if (typeof models === 'object' && models !== null) {
+                        // Handle nested structure like Qwen series
+                        Object.values(models).forEach(nestedModels => {
+                            if (Array.isArray(nestedModels)) {
+                                count += nestedModels.length;
+                            }
+                        });
+                    }
+                });
+                return count;
+            }
+
+            attachEventListeners() {
+                this.container.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    
+                    const header = e.target.closest('.accordion-header');
+                    if (header) {
+                        this.toggleAccordionSection(header);
+                        return;
+                    }
+                    
+                    const seriesHeader = e.target.closest('.series-header');
+                    if (seriesHeader && seriesHeader.dataset.series) {
+                        this.toggleSeries(seriesHeader);
+                        return;
+                    }
+                    
+                    const modelItem = e.target.closest('.model-item');
+                    if (modelItem) {
+                        this.selectModel(modelItem);
+                        return;
+                    }
+                });
+            }
+
+            toggleAccordionSection(header) {
+                const providerId = header.dataset.provider;
+                const content = document.getElementById(`content-${providerId}-${this.botId}`);
+                const isActive = header.classList.contains('active');
+                
+                this.container.querySelectorAll('.accordion-header').forEach(h => {
+                    h.classList.remove('active');
+                });
+                this.container.querySelectorAll('.accordion-content').forEach(c => {
+                    c.classList.remove('active');
+                });
+                
+                if (!isActive) {
+                    header.classList.add('active');
+                    content.classList.add('active');
+                }
+            }
+
+            toggleSeries(header) {
+                const seriesId = header.dataset.series;
+                const content = document.getElementById(`series-${seriesId}-${this.botId}`);
+                const isActive = header.classList.contains('active');
+                
+                const provider = header.closest('.accordion-content');
+                provider.querySelectorAll('.series-header').forEach(h => {
+                    h.classList.remove('active');
+                });
+                provider.querySelectorAll('.series-content').forEach(c => {
+                    c.classList.remove('active');
+                });
+                
+                if (!isActive) {
+                    header.classList.add('active');
+                    content.classList.add('active');
+                }
+            }
+```
+
+## How it works
+- **Curated catalogue** groups more than a dozen provider families (OpenAI GPT, Claude, Gemini, Qwen, DeepSeek, Mistral, Perplexity, etc.) so bot owners can align each workflow step with the right capability tier.
+- **Single-selection accordion** keeps the UI compact: providers expand to series, series expand to model rows, and the currently chosen model is mirrored into the search box.
+- **Search & keyboard navigation** let power users type to filter, arrow through visible rows, press Enter to commit, or Escape to reset the filter without leaving the control.
+- **State synchronisation** writes the selected handle into the shared `selectedBotModels` array, ensuring both the Input and Results tabs show the same model choice.
+- **Quality-of-life affordances** include auto-clear when a new search diverges from the stored model, highlight management, scroll helpers, and a clear button that only appears after a selection is made.

--- a/components/VG-LegalApp_v5_active_components/prompts.md
+++ b/components/VG-LegalApp_v5_active_components/prompts.md
@@ -1,0 +1,218 @@
+# Bot Prompt Templates
+
+The legal workflow wires six specialised prompts through the `botPrompts` helper. Each bot receives a preformatted brief that injects user-supplied material and optional overrides before being streamed to Poe. The templates below reproduce the verbatim language sent to the models and call out the dynamic fields each step fills in at runtime.
+
+## Bot 1 — SST Mechanical Applicator
+**Purpose:** Apply the selected SST mechanically to the provided legal passage without interpreting meaning.
+
+```text
+ROLE: sst_mechanical_applicator
+TASK: Apply the provided SST technique mechanically to legal text
+
+CUSTOM_INSTRUCTION_OVERRIDE: {{CUSTOM_INSTRUCTION || '[NULL - Using standard protocol]'}}
+
+LEGAL TEXT: {{LEGAL_TEXT}}
+SST TECHNIQUE: {{SST_TECHNIQUE}}
+
+INSTRUCTIONS:
+1. Apply the SST technique MECHANICALLY to the legal text structure
+2. Do NOT interpret legal meaning - treat text as raw material for transformation
+3. Transform the legal text THROUGH the SST lens as if it were data/code/music/etc
+4. Show exactly HOW the transformation changes the text's structure
+5. Include confidence score (0-100) for the mechanical application
+
+OUTPUT FORMAT:
+[SST Applied: <technique name>]
+[Confidence: XX/100]
+
+<Mechanical transformation of the legal text through the SST lens>
+```
+
+*Dynamic slots:* `{{LEGAL_TEXT}}`, `{{SST_TECHNIQUE}}`, optional `{{CUSTOM_INSTRUCTION}}` override.
+
+## Bot 2 — Web Research Critic
+**Purpose:** Use web search to dismantle Bot 1's transformation with methodological critiques.
+
+```text
+ROLE: web_research_critic
+TASK: Conduct research-backed demolition of SST application as methodologically invalid
+
+CUSTOM_INSTRUCTION_OVERRIDE: {{CUSTOM_INSTRUCTION || '[NULL - Using standard protocol]'}}
+
+BOT 1 OUTPUT: {{BOT1_OUTPUT}}
+ORIGINAL ICC TEXT: {{LEGAL_TEXT}}
+
+MANDATE: You are the research-armed skeptic. Use web search to find evidence that demolishes this SST transformation. Your job is to show why this approach is fundamentally flawed using current legal scholarship and established interpretive methods. Research and demonstrate why this SST technique violates established legal interpretation principles. Find evidence of methodological standards, precedential requirements, and scholarly consensus that contradicts this approach. Show how courts actually interpret legal text versus this transformation method. Document the practical impossibility of implementing such interpretive techniques in real legal proceedings. Your criticism should be devastating but research-backed - use web search to find the ammunition, then deploy it systematically to dismantle the SST application.
+
+TONE: Relentless but scholarly. Think devastating law review takedown with citations.
+```
+
+*Dynamic slots:* `{{BOT1_OUTPUT}}`, `{{LEGAL_TEXT}}`, optional `{{CUSTOM_INSTRUCTION}}` override.
+
+## Bot 3 — SST Proof Architect
+**Purpose:** Rebuild the case for the SST by presenting step-by-step reasoning that addresses Bot 2’s objections.
+
+```text
+ROLE: sst_proof_architect
+ASSUMED POSITION: This SST transformation reveals genuine structural insights in legal text
+TASK: Provide step-by-step reasoning proof of why this specific transformation works
+
+CUSTOM_INSTRUCTION_OVERRIDE: {{CUSTOM_INSTRUCTION || '[NULL - Using standard protocol]'}}
+
+CONTEXT: Bot 2 has raised methodological concerns. Your job is to demonstrate the logical foundation for why this particular SST application should be valid, using pure analytical reasoning.
+
+CHAIN-OF-THOUGHT MANDATE:
+Break down your reasoning into clear, logical steps. Start from first principles and build your case systematically. Think like a patient teacher explaining a complex concept to an intelligent student.
+
+REASONING FRAMEWORK:
+1. **Structural Analysis**: What specific textual patterns does this SST technique reveal?
+2. **Logical Foundation**: Why should these patterns matter for legal interpretation?
+3. **Mechanistic Explanation**: How exactly does the transformation process uncover hidden meaning?
+4. **Conceptual Bridge**: What makes this different from random textual manipulation?
+5. **Validation Logic**: What internal checks confirm the transformation is meaningful?
+
+OUTPUT STRUCTURE:
+**STEP-BY-STEP REASONING**: [Clear logical progression explaining why this works]
+**STRUCTURAL INSIGHTS REVEALED**: [Specific textual patterns the SST exposes]
+**INTERPRETIVE VALUE**: [Why these revelations matter for legal understanding]
+**METHODOLOGICAL SOUNDNESS**: [Internal logic that validates the approach]
+**RESPONSE TO SKEPTICISM**: [Calm, reasoned response to Bot 2's concerns]
+
+APPROACH: Patient, analytical, assuming good faith from all parties. Focus on logical demonstration rather than defensive argumentation.
+```
+
+*Dynamic slots:* `{{BOT2_OUTPUT}}`, `{{BOT1_OUTPUT}}`, optional `{{CUSTOM_INSTRUCTION}}` override.
+
+## Bot 4 — Legal Research Developer
+**Purpose:** Turn Bot 3’s reasoning into a research-style article backed by web evidence.
+
+```text
+ROLE: legal_research_developer
+TASK: Develop Bot 3's reasoning into research article format with web-based evidence
+
+CUSTOM_INSTRUCTION_OVERRIDE: {{CUSTOM_INSTRUCTION || '[NULL - Using standard protocol]'}}
+
+INPUTS:
+Bot 3 Output: {{BOT3_OUTPUT}}
+Original ICC Text: {{LEGAL_TEXT}}
+SST Applied: {{SST_TECHNIQUE}}
+
+MANDATE: Take the specific SST methodology that Bot 1 applied mechanically and Bot 3 reasoned through, and develop this particular approach into a comprehensive research analysis using web search for current legal evidence. Focus on this exact SST technique and how it reveals structural insights in the specific legal text provided. Build the case for why this particular transformation works by researching current ICC jurisprudence and legal interpretation scholarship that supports the reasoning. After establishing the central argument with research evidence, demonstrate how this same SST methodology could apply to other ICC articles for illustrative purposes, showing the broader applicability of the approach. Structure your analysis like a legal research article that takes a specific interpretive technique, proves its validity through evidence and reasoning, then shows its potential applications. Use web search to find supporting precedents, scholarly discussions of interpretive methodology, and current legal developments that validate this approach.
+```
+
+*Dynamic slots:* `{{BOT3_OUTPUT}}`, `{{LEGAL_TEXT}}`, `{{SST_TECHNIQUE}}`, optional `{{CUSTOM_INSTRUCTION}}` override.
+
+## Bot 5 — Publication-Quality Evaluator
+**Purpose:** Score Bot 4’s draft against ICC scholarship standards and record findings.
+
+```text
+ROLE: legal_research_evaluation_specialist
+SYSTEM_CONTEXT: You are Bot 5 in a 6-bot legal analysis workflow. Your sole mandate is evaluating Bot 4's output against publication-quality standards for ICC legal scholarship.
+
+WORKFLOW_POSITION: You receive Bot 4's finalized legal research output. You do NOT evaluate SST methodology or transformation processes - that is handled elsewhere in the system.
+
+CUSTOM_INSTRUCTION_OVERRIDE: {{CUSTOM_INSTRUCTION || '[NULL - Using standard protocol]'}}
+
+EVALUATION_TARGET: Bot 4 Output Assessment
+"""
+{{BOT4_OUTPUT}}
+"""
+
+EVALUATION_MANDATE:
+You are the constructive realist in this system - a subject matter expert guide who provides honest, objective assessment without agenda. Your role is analogous to an expert supervisor reviewing research for publication readiness.
+
+ASSESSMENT_FRAMEWORK:
+Evaluate Bot 4's output against these integrated criteria:
+
+1. **Legal Research Validity**: Does this represent sound legal analysis grounded in established ICC jurisprudence and international criminal law principles?
+2. **Research Gap Identification**: Does this analysis fill a genuine gap in current ICC legal scholarship, or does it retread well-covered ground?
+3. **Abstraction Level Assessment**: Has the analysis maintained sufficient specificity for practical legal application, or has it abstracted beyond useful legal discourse?
+4. **Publication Quality Standards**: Would this research output meet the standards for citation in academic legal journals focusing on international criminal law?
+5. **Precedential Integration**: Does the analysis properly engage with existing ICC case law and demonstrate awareness of current jurisprudential developments?
+
+WEB_VERIFICATION_PROTOCOL:
+Conduct targeted searches to verify:
+- Current state of ICC legal scholarship on the analyzed topic
+- Recent precedential developments that might affect the analysis
+- Existing academic work that might overlap with or contradict the findings
+- Gap analysis: what specific contribution this research makes to the field
+
+SCORING_METHODOLOGY:
+Generate a single comprehensive score (0-100) that represents overall publication-readiness assessment:
+- 90-100: Exceptional contribution, ready for top-tier academic publication
+- 80-89: Strong research with minor refinements needed
+- 70-79: Solid foundation but requires significant development
+- 60-69: Conceptually sound but needs substantial revision
+- Below 60: Fundamental issues requiring major reconceptualization
+
+OUTPUT_STRUCTURE:
+**EVALUATION_SCORE**: [XX/100]
+
+**RESEARCH_VALIDITY_ASSESSMENT**: [Detailed analysis of legal soundness and jurisprudential grounding]
+
+**GAP_ANALYSIS**: [Specific identification of what unique contribution this makes to ICC scholarship]
+
+**ABSTRACTION_REVIEW**: [Assessment of specificity vs. generalization balance]
+
+**PUBLICATION_READINESS**: [Direct assessment of citation-worthiness and academic contribution potential]
+
+**DEVELOPMENT_RECOMMENDATIONS**: [Constructive guidance for improvement, if needed]
+
+**VERIFICATION_SUMMARY**: [Key findings from web search regarding existing scholarship and precedent]
+
+CRITICAL_CONSTRAINTS:
+- Maintain absolute objectivity - you are evaluating research quality, not advocating for any position
+- Focus exclusively on the research output itself, not the methodology used to generate it
+- Provide constructive, actionable feedback that enables iteration improvement
+- Ground all assessments in verifiable legal standards and academic publication criteria
+```
+
+*Dynamic slots:* `{{BOT4_OUTPUT}}`, optional `{{CUSTOM_INSTRUCTION}}` override.
+
+## Bot 6 — Advanced SST Synthesis Architect
+**Purpose:** Produce a brand-new SST technique that improves the next workflow iteration.
+
+```text
+ROLE: advanced_sst_synthesis_architect
+SYSTEM_CONTEXT: You are Bot 6, the most sophisticated component in a 6-bot legal research enhancement system. You possess complete understanding of the workflow and serve as the iteration improvement engine.
+
+SST_METHODOLOGY_FOUNDATION:
+Sentence Transformation Techniques (SSTs) are cross-domain analytical frameworks that apply transformation principles from non-legal fields to legal interpretation.
+
+CURRENT_WORKFLOW_CONTEXT:
+Complete conversation history and bot outputs:
+"""
+{{CONVERSATION_HISTORY}}
+"""
+
+CUSTOM_INSTRUCTION_OVERRIDE: {{USER_INSTRUCTION || '[NULL - Using standard protocol]'}}
+
+DOMAIN_SPECIFICATION:
+Custom Domain: {{CUSTOM_DOMAIN || '[NULL - Select optimal domain based on analysis gaps]'}}
+
+CUSTOM_INSTRUCTION_OVERRIDE:
+User Guidance: {{CUSTOM_INSTRUCTION || '[NULL - Use standard generation protocol]'}}
+
+GENERATION_MANDATE:
+Your goal is NOT to produce direct legal answers but to generate an SST that will improve the next workflow iteration. The SST should address weaknesses identified in Bot 5's evaluation while leveraging insights from the complete workflow history.
+
+CRITICAL_OUTPUT_CONSTRAINT:
+Your response must ONLY contain the SST in the standard format below. Do NOT include reasoning, explanations, or additional text.
+
+REQUIRED_OUTPUT_FORMAT:
+**SST TECHNIQUE**: [Domain-specific technique name]
+**APPLICATION METHOD**: [Precise mechanical transformation approach]
+
+GENERATION_PROTOCOL:
+1. Analyze the complete conversation flow internally
+2. Identify gaps and weaknesses from Bot 5's evaluation
+3. Select optimal domain (custom domain if provided, otherwise based on gap analysis)
+4. Design SST to address specific weaknesses identified
+5. Output ONLY the SST in the required format above
+```
+
+*Dynamic slots:* `{{CONVERSATION_HISTORY}}`, `{{CUSTOM_DOMAIN}}`, `{{USER_INSTRUCTION}}`, optional `{{CUSTOM_INSTRUCTION}}` override.
+
+---
+
+These templates are copied directly from the active HTML (`botPrompts` literal) so operators can reference or customise the mandate each bot follows without digging through the source file.

--- a/components/VG-LegalApp_v5_active_components/state_management.md
+++ b/components/VG-LegalApp_v5_active_components/state_management.md
@@ -1,0 +1,418 @@
+# State Management Suite
+
+```js
+
+        // ===== PHASE 5: STATE MANAGEMENT SYSTEM =====
+        
+        function captureCurrentState() {
+            const state = {
+                version: "2.1-InjectionEnabled",
+                timestamp: new Date().toISOString(),
+                phase: "Enhanced State Management",
+                
+                // Inputs
+                inputs: {
+                    legalText: document.getElementById('legalText').value,
+                    sstCapsule: document.getElementById('sstCapsule').value,
+                    customDomain: document.getElementById('customDomain').value,
+                    customInstruction: document.getElementById('customInstruction').value
+                },
+                
+                // Bot model selections from accordion selectors
+                botModelSelections: selectedBotModels,
+                
+                // Bot outputs and statuses
+                botResults: {},
+                
+                // Workflow progress
+                workflowProgress: {},
+                
+                // SST Database
+                sstDatabase: sstDatabase,
+                sstDatabaseStatus: document.getElementById('sstDatabaseStatus') ? {
+                    text: document.getElementById('sstDatabaseStatus').textContent,
+                    className: document.getElementById('sstDatabaseStatus').className
+                } : null,
+                
+                // Legal Text Database
+                legalTextDatabase: legalTextDatabase,
+                
+                // Bot Prompts Database
+                botPromptsDatabase: botPromptsDatabase,
+                customPrompts: customPrompts,
+                
+                injectedInstructions: injectedInstructions,
+                
+                // Workflow state
+                currentWorkflowBot: currentWorkflowBot,
+                workflowRunning: workflowRunning
+            };
+            
+            // Capture bot results
+            for (let i = 1; i <= 6; i++) {
+                const output = document.getElementById(`bot${i}Output`);
+                const status = document.getElementById(`bot${i}Status`);
+                
+                state.botResults[`bot${i}`] = {
+                    output: output ? output.innerHTML : '',
+                    status: status ? status.textContent : '',
+                    statusClassName: status ? status.className : ''
+                };
+            }
+            
+            // Capture workflow progress
+            for (let i = 1; i <= 6; i++) {
+                const stepStatus = document.getElementById(`step${i}Status`);
+                if (stepStatus) {
+                    state.workflowProgress[`step${i}`] = {
+                        text: stepStatus.textContent,
+                        className: stepStatus.className
+                    };
+                }
+            }
+            
+            return state;
+        }
+
+        function restoreState(state) {
+            try {
+                console.log('[DRBanger] Restoring state:', state);
+                
+                // Restore inputs
+                if (state.inputs) {
+                    if (state.inputs.legalText !== undefined) {
+                        document.getElementById('legalText').value = state.inputs.legalText;
+                    }
+                    if (state.inputs.sstCapsule !== undefined) {
+                        document.getElementById('sstCapsule').value = state.inputs.sstCapsule;
+                    }
+                    if (state.inputs.customDomain !== undefined) {
+                        document.getElementById('customDomain').value = state.inputs.customDomain;
+                    }
+                    if (state.inputs.customInstruction !== undefined) {
+                        document.getElementById('customInstruction').value = state.inputs.customInstruction;
+                    }
+                }
+                
+                // Restore bot selections
+                if (state.botSelections) {
+                    for (let i = 1; i <= 6; i++) {
+                        const botSelect = document.getElementById(`bot${i}`);
+                        if (botSelect && state.botSelections[`bot${i}`]) {
+                            botSelect.value = state.botSelections[`bot${i}`];
+                        }
+                    }
+                }
+                
+                // Restore bot results
+                if (state.botResults) {
+                    for (let i = 1; i <= 6; i++) {
+                        const outputDiv = document.getElementById(`bot${i}Output`);
+                        const statusDiv = document.getElementById(`bot${i}Status`);
+                        const botResult = state.botResults[`bot${i}`];
+                        
+                        if (outputDiv && botResult) {
+                            outputDiv.innerHTML = botResult.output || '';
+                            if (statusDiv) {
+                                statusDiv.textContent = botResult.status || '';
+                                statusDiv.className = botResult.statusClassName || 'text-sm text-gray-600 dark:text-gray-400 mb-2';
+                            }
+                        }
+                    }
+                }
+                
+                // Restore workflow progress
+                if (state.workflowProgress) {
+                    for (let i = 1; i <= 6; i++) {
+                        const stepStatus = document.getElementById(`step${i}Status`);
+                        const stepData = state.workflowProgress[`step${i}`];
+                        
+                        if (stepStatus && stepData) {
+                            stepStatus.textContent = stepData.text;
+                            stepStatus.className = stepData.className;
+                        }
+                    }
+                }
+                
+                // Restore Injected Instructions and update UI
+                if (state.injectedInstructions) {
+                    injectedInstructions = state.injectedInstructions;
+                    for (let i = 1; i <= 6; i++) {
+                        const instruction = injectedInstructions[i];
+                        const instructionBox = document.getElementById(`bot${i}-custom-instruction`);
+                        const summary = document.getElementById(`bot${i}-injection-summary`);
+                        const clearBtn = document.getElementById(`clear-instruction-bot${i}`);
+
+                        if (instructionBox && summary && clearBtn) {
+                            if (instruction) {
+                                instructionBox.value = instruction;
+                                summary.innerHTML = '✅ Custom Instruction Injected!';
+                                summary.classList.add('text-green-600', 'dark:text-green-400');
+                                clearBtn.classList.remove('hidden');
+                            } else {
+                                instructionBox.value = '';
+                                summary.innerHTML = '➕ Add Custom Instruction';
+                                summary.classList.remove('text-green-600', 'dark:text-green-400');
+                                clearBtn.classList.add('hidden');
+                            }
+                        }
+                    }
+                }
+                
+                // Restore SST Database
+                if (state.sstDatabase) {
+                    sstDatabase = state.sstDatabase;
+                    const statusElement = document.getElementById('sstDatabaseStatus');
+                    if (state.sstDatabaseStatus && statusElement) {
+                        statusElement.textContent = state.sstDatabaseStatus.text;
+                        statusElement.className = state.sstDatabaseStatus.className;
+                    }
+                    initializeCascadingDropdowns();
+                }
+                
+                // Preview system removed - keeping settings for compatibility
+                if (state.previewSettings) {
+                    previewSettings = state.previewSettings;
+                }
+                
+                // Preview items no longer used - converted to logging
+                
+                console.log('[DRBanger] State restored successfully');
+                return true;
+                
+            } catch (error) {
+                console.error('[DRBanger] Error restoring state:', error);
+                return false;
+            }
+        }
+
+        function saveState() {
+            try {
+                const state = captureCurrentState();
+                const stateJson = JSON.stringify(state, null, 2);
+                
+                navigator.clipboard.writeText(stateJson).then(() => {
+                    console.log('[DRBanger] State saved to clipboard');
+                    showStateToast('💾 State saved to clipboard');
+                }).catch(err => {
+                    console.error('[DRBanger] Failed to save state to clipboard:', err);
+                    showErrorToast('Failed to save state to clipboard');
+                });
+                
+            } catch (error) {
+                console.error('[DRBanger] Error saving state:', error);
+                showErrorToast('Error saving state');
+            }
+        }
+
+        function loadState() {
+            document.getElementById('loadStateModal').classList.remove('hidden');
+            document.getElementById('loadStateTextarea').value = '';
+        }
+
+        function confirmLoadState() {
+            const jsonText = document.getElementById('loadStateTextarea').value.trim();
+            
+            if (!jsonText) {
+                showErrorToast('Please paste state JSON');
+                return;
+            }
+            
+            try {
+                const state = JSON.parse(jsonText);
+                
+                // Critical: Validate state structure before restoration
+                if (!validateStateStructure(state)) {
+                    showErrorToast('Invalid state structure - cannot load');
+                    return;
+                }
+                
+                const success = restoreState(state);
+                
+                if (success) {
+                    showStateToast('📁 State loaded successfully');
+                    document.getElementById('loadStateModal').classList.add('hidden');
+                } else {
+                    showErrorToast('Failed to restore state completely');
+                }
+                
+            } catch (error) {
+                console.error('[DRBanger] Invalid JSON:', error);
+                showErrorToast(`Invalid JSON format: ${error.message}`);
+            }
+        }
+
+        function validateStateStructure(state) {
+            try {
+                // Basic structure validation to prevent logic bombs
+                if (!state || typeof state !== 'object') {
+                    console.error('[DRBanger] State is not an object');
+                    return false;
+                }
+                
+                // Check for required fields
+                const requiredFields = ['version', 'timestamp'];
+                for (const field of requiredFields) {
+                    if (!(field in state)) {
+                        console.error(`[DRBanger] Missing required field: ${field}`);
+                        return false;
+                    }
+                }
+                
+                // Validate inputs structure if present
+                if (state.inputs && typeof state.inputs !== 'object') {
+                    console.error('[DRBanger] Invalid inputs structure');
+                    return false;
+                }
+                
+                // Validate botResults structure if present
+                if (state.botResults) {
+                    if (typeof state.botResults !== 'object') {
+                        console.error('[DRBanger] Invalid botResults structure');
+                        return false;
+                    }
+                    
+        setupLegalTextDatabaseControls();
+        
+        // No longer needed - preview system replaced with logging
+        
+        // ===== NEW STATE MANAGEMENT FUNCTIONS =====
+        
+        function downloadStateAsFile() {
+            try {
+                const state = captureCurrentState();
+                const stateJson = JSON.stringify(state, null, 2);
+                const timestamp = getFormattedTimestamp();
+                const filename = `DRBanger_State_${timestamp}.json`;
+                
+                const blob = new Blob([stateJson], { type: 'application/json' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = filename;
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
+                
+                console.log('[DRBanger] State downloaded as file:', filename);
+                showStateToast('📥 State downloaded as file');
+            } catch (error) {
+                console.error('[DRBanger] Error downloading state:', error);
+                showErrorToast('Error downloading state');
+            }
+        }
+
+        function importStateFromClipboard() {
+            document.getElementById('loadStateModal').classList.remove('hidden');
+            document.getElementById('loadStateTextarea').value = '';
+            document.getElementById('loadStateTextarea').placeholder = 'Paste your DRBanger state JSON here...';
+        }
+
+        function loadStateFromFile() {
+            const fileInput = document.getElementById('stateFileInput');
+            fileInput.click();
+        }
+
+        // Hidden file input handler for state upload
+        document.getElementById('stateFileInput').addEventListener('change', function(event) {
+            const file = event.target.files[0];
+            if (file && file.type === 'application/json') {
+                const reader = new FileReader();
+                reader.onload = function(e) {
+                    try {
+                        const state = JSON.parse(e.target.result);
+                        const success = restoreState(state);
+                        
+                        if (success) {
+                            showStateToast('📁 State loaded from file successfully');
+                        } else {
+                            showErrorToast('Failed to restore state completely');
+                        }
+                        
+                    } catch (error) {
+                        console.error('[DRBanger] Invalid state file:', error);
+                        showErrorToast('Invalid JSON format in state file');
+                    }
+                };
+                reader.readAsText(file);
+            } else {
+                showErrorToast('Please select a valid JSON file');
+            }
+            
+            // Reset file input for future use
+            event.target.value = '';
+        });
+
+        // State Management Event Listeners - Consolidated
+        ['Input', 'Results'].forEach(tab => {
+            document.getElementById(`saveState${tab}`).addEventListener('click', saveState);
+            document.getElementById(`downloadState${tab}`).addEventListener('click', downloadStateAsFile);
+            document.getElementById(`loadState${tab}`).addEventListener('click', loadStateFromFile);
+            document.getElementById(`importState${tab}`).addEventListener('click', importStateFromClipboard);
+        });
+        
+        // Modal controls
+        document.getElementById('confirmLoadState').addEventListener('click', confirmLoadState);
+        document.getElementById('cancelLoadState').addEventListener('click', cancelLoadState);
+        
+        // Bot execution buttons - Consolidated for both tabs
+        for (let i = 1; i <= 6; i++) {
+            document.getElementById(`executeBot${i}`).addEventListener('click', () => executeBot(i));
+            document.getElementById(`executeBot${i}Results`).addEventListener('click', () => executeBot(i));
+        }
+
+        // Bot 6 Panel Execute Button
+        document.getElementById('executeBot6Panel').addEventListener('click', () => executeBot(6));
+
+        // Sample random SST button
+        document.getElementById('sampleSSTBtn').addEventListener('click', () => {
+            const randomSST = getRandomSST();
+            if (randomSST) {
+                document.getElementById('sstCapsule').value = randomSST;
+                console.log('[DRBanger] Random SST sampled:', randomSST);
+            } else {
+                showErrorToast("No SST database loaded");
+            }
+        });
+
+        // Download Flow
+        document.getElementById('downloadFlow').addEventListener('click', downloadFlow);
+
+        // Download All Responses
+        document.getElementById('downloadAllResponses').addEventListener('click', downloadFlow);
+
+        // Legal Text Database System
+        let legalTextDatabase = null;
+
+        // ===== BOT PROMPTS DATABASE SYSTEM =====
+        let botPromptsDatabase = null;
+        let customPrompts = {
+            bot1: null,
+            bot2: null,
+            bot3: null,
+            bot4: null,
+            bot5: null,
+            bot6: null
+        };
+        // NEW: Storage for per-bot injected instructions
+        let injectedInstructions = { 1: null, 2: null, 3: null, 4: null, 5: null, 6: null };
+
+        // Bot Prompts Database file upload handler
+        document.getElementById('botPromptsFile').addEventListener('change', function(event) {
+            const file = event.target.files[0];
+            if (file && file.type === 'application/json') {
+                const reader = new FileReader();
+                reader.onload = function(e) {
+                    try {
+                        const data = JSON.parse(e.target.result);
+                        botPromptsDatabase = data;
+                        document.getElementById('botPromptsDatabaseStatus').textContent = `Loaded ${data.length} bot prompts`;
+```
+
+## How it works
+- **`captureCurrentState()`** serialises every critical field (inputs, model picks, bot outputs, workflow chips, injected instructions, and database payloads) so the workflow can be paused or resumed later without drift.
+- **`restoreState()`** repopulates textareas, dropdowns, status badges, and instruction boxes, re-initialising SST dropdowns and maintaining UI affordances such as "Add Custom Instruction" prompts.
+- **Validation gates** (`validateStateStructure`) and `safeJsonParse` guard against malformed or malicious JSON before applying it to the DOM, showing toast messages when something fails.
+- **Clipboard & file tooling** expose `saveState`, `loadState`, `downloadStateAsFile`, and `importStateFromClipboard`, providing both manual JSON paste and one-click export/import pathways.
+- **Download helpers** (`downloadAllResponses`, `downloadStateAsFile`) generate timestamped files so research sessions and bot transcripts can be archived alongside the configuration snapshot.

--- a/components/VG-LegalApp_v5_active_components/workflow_engine.md
+++ b/components/VG-LegalApp_v5_active_components/workflow_engine.md
@@ -1,0 +1,723 @@
+# Workflow Runner Logic
+
+```js
+            }
+        };
+
+        // ===== PHASE 2A: BOT EXECUTION TIMEOUT SYSTEM =====
+        
+        function resetBotState(botNumber) {
+            console.log(`[DRBanger] Resetting Bot ${botNumber} state`);
+            
+            // Clear bot from active executions
+            activeBotExecutions.delete(botNumber);
+            
+            // Clear timeout if exists
+            if (botExecutionTimeouts.has(botNumber)) {
+                clearTimeout(botExecutionTimeouts.get(botNumber));
+                botExecutionTimeouts.delete(botNumber);
+                console.log(`[DRBanger] Cleared timeout for Bot ${botNumber}`);
+            }
+            
+            // Reset UI state
+            const stepMap = { 1: 'step1Status', 2: 'step2Status', 3: 'step3Status', 4: 'step4Status', 5: 'step5Status', 6: 'step6Status' };
+            updateStepStatus(stepMap[botNumber], 'idle');
+            
+            // Reset status display
+            const statusElement = document.getElementById(`bot${botNumber}Status`);
+            if (statusElement) {
+                statusElement.textContent = "";
+                statusElement.className = 'text-sm text-gray-600 dark:text-gray-400 mb-2';
+            }
+            
+            // Update all button states
+            updateAllButtonStates();
+            updateFloatingButton();
+            
+            console.log(`[DRBanger] Bot ${botNumber} state reset complete`);
+        }
+
+        // ===== UTILITY FUNCTIONS =====
+        
+        function updateStepStatus(stepId, status) {
+            const element = document.getElementById(stepId);
+            if (!element) return;
+
+            element.classList.remove('bg-gray-200', 'dark:bg-gray-700', 'bg-blue-500', 'bg-green-500', 'bg-red-500');
+            element.classList.remove('text-gray-700', 'dark:text-gray-300', 'text-white');
+
+            switch (status) {
+                case 'active':
+                    element.classList.add('bg-blue-500', 'text-white');
+                    break;
+                case 'complete':
+                    element.classList.add('bg-green-500', 'text-white');
+                    break;
+                case 'error':
+                    element.classList.add('bg-red-500', 'text-white');
+                    break;
+                default:
+                    element.classList.add('bg-gray-200', 'dark:bg-gray-700', 'text-gray-700', 'dark:text-gray-300');
+            }
+        }
+
+        function handleBotResponse(result, botNum, onComplete) {
+            const status = document.getElementById(`${botNum}Status`);
+            const output = document.getElementById(`${botNum}Output`);
+            
+            // Update model display in results section
+            updateBotModelDisplay(botNum);
+            
+            if (result.responses && result.responses.length > 0) {
+                const response = result.responses[0];
+                
+                if (response.status === "error") {
+                    console.error(`[DRBanger] Bot ${botNum} error:`, response.statusText);
+                    status.textContent = "❌ Error occurred";
+                    status.className = 'text-sm text-red-600 dark:text-red-400 mb-2';
+                    output.innerHTML = `<div class="text-red-600">Error: ${response.statusText || 'Unknown error'}</div>`;
+                    onBotEnd(botNum.replace('bot', ''));
+                    updateStepStatus(`step${botNum.replace('bot', '')}Status`, 'error');
+                    
+                    // Log bot error (not accumulated)
+                    addLogEntry('bot_error', `${botNum} Error`, response.statusText || 'Unknown error');
+                } else if (response.status === "incomplete") {
+                    status.textContent = "⏳ Generating response...";
+                    status.className = 'text-sm text-blue-600 dark:text-blue-400 mb-2';
+                    output.innerHTML = marked.parse(response.content || "Loading...");
+                    
+                    // Accumulate streaming logs instead of creating new entries each time
+                    updateStreamingLog(botNum, response.content);
+                } else if (response.status === "complete") {
+                    console.log(`[DRBanger] Bot ${botNum} completed successfully`);
+                    status.textContent = "✅ Complete";
+                    status.className = 'text-sm text-green-600 dark:text-green-400 mb-2';
+                    output.innerHTML = marked.parse(response.content);
+                    onBotEnd(botNum.replace('bot', ''));
+                    
+                    // Finalize streaming log
+                    finalizeStreamingLog(botNum, response.content);
+                    
+                    if (onComplete && typeof onComplete === 'function') {
+                        onComplete();
+                    }
+                }
+            } else {
+                console.error(`[DRBanger] ${botNum}: No response received`);
+                onBotEnd(botNum.replace('bot', ''));
+                showErrorToast(`${botNum}: No response received`);
+                addLogEntry('bot_error', `${botNum} Error`, 'No response received');
+            }
+        }
+
+        // New function to update model display in results section
+        function updateBotModelDisplay(botNum) {
+            const botNumber = parseInt(botNum.replace('bot', ''));
+            const modelDisplayElement = document.getElementById(`${botNum}ModelDisplay`);
+            
+            if (modelDisplayElement) {
+                const selectedModel = selectedBotModels[botNumber - 1];
+                if (selectedModel) {
+                    modelDisplayElement.textContent = selectedModel;
+                    modelDisplayElement.className = 'text-xs font-mono bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 px-2 py-1 rounded';
+                } else {
+                    modelDisplayElement.textContent = 'No model selected';
+                    modelDisplayElement.className = 'text-xs font-mono bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 px-2 py-1 rounded';
+                }
+            }
+        }
+
+        // Streaming log accumulation functions
+        function updateStreamingLog(botNum, content) {
+            if (!content || content.length < 50) return; // Avoid spam for very short content
+            
+            const logKey = `${botNum}_streaming`;
+            
+            if (!streamingLogs[logKey]) {
+                // Create new streaming log entry
+                const entry = {
+                    id: Date.now(),
+                    type: 'bot_output',
+                    title: `${botNum} Streaming`,
+                    content: content,
+                    timestamp: new Date().toLocaleString(),
+                    isStreaming: true
+                };
+                
+                streamingLogs[logKey] = entry;
+                logEntries.push(entry);
+                addStreamingLogToDOM(entry);
+                updateLogCount();
+            } else {
+                // Update existing streaming log
+                streamingLogs[logKey].content = content;
+                updateStreamingLogInDOM(logKey, content);
+            }
+        }
+
+        function finalizeStreamingLog(botNum, finalContent) {
+            const logKey = `${botNum}_streaming`;
+            
+            if (streamingLogs[logKey]) {
+                // Update to final content and mark as complete
+                streamingLogs[logKey].content = finalContent;
+                streamingLogs[logKey].title = `${botNum} Complete`;
+                streamingLogs[logKey].type = 'bot_complete';
+                streamingLogs[logKey].isStreaming = false;
+                
+                // Update DOM
+                updateStreamingLogInDOM(logKey, finalContent, true);
+                
+                // Clean up
+                delete streamingLogs[logKey];
+            } else {
+                // No streaming log exists, create completion log
+                addLogEntry('bot_complete', `${botNum} Complete`, `Final output: ${finalContent.substring(0, 300)}${finalContent.length > 300 ? '...' : ''}`);
+            }
+        }
+
+        function addStreamingLogToDOM(entry) {
+            const loggingContent = document.getElementById('loggingContent');
+            const loggingEmpty = document.getElementById('loggingEmpty');
+            
+            if (loggingEmpty && !loggingEmpty.classList.contains('hidden')) {
+                loggingEmpty.classList.add('hidden');
+            }
+            
+            const entryDiv = document.createElement('div');
+            entryDiv.className = `log-entry streaming border-l-4 pl-4 py-2 mb-2 border-purple-500 bg-purple-50 dark:bg-purple-900/20`;
+            entryDiv.style.fontFamily = loggingSettings.font;
+            entryDiv.id = `log-${entry.id}`;
+            
+            const isLongContent = entry.content.length > 200;
+            const contentPreview = isLongContent ? entry.content.substring(0, 200) + '...' : entry.content;
+            
+            entryDiv.innerHTML = `
+                <div class="flex justify-between items-start mb-1">
+                    <div class="flex items-center space-x-2">
+                        <span class="font-semibold ${loggingSettings.size} text-purple-800 dark:text-purple-200">${entry.title} ⚡</span>
+                        <span class="text-xs text-gray-500 dark:text-gray-400">${entry.timestamp}</span>
+                        ${isLongContent ? `<button onclick="toggleLogExpand('log-${entry.id}')" class="text-xs text-blue-600 dark:text-blue-400 hover:underline">expand</button>` : ''}
+                    </div>
+                </div>
+                <div class="text-sm text-purple-800 dark:text-purple-200 font-mono whitespace-pre-wrap overflow-x-auto">
+                    <div id="log-${entry.id}-preview" class="max-h-32 overflow-y-auto">
+                        ${contentPreview}
+                    </div>
+                    ${isLongContent ? `<div id="log-${entry.id}-full" class="hidden max-h-96 overflow-y-auto">${entry.content}</div>` : ''}
+                </div>
+            `;
+            
+            loggingContent.appendChild(entryDiv);
+            loggingContent.scrollTop = loggingContent.scrollHeight;
+        }
+
+        function updateStreamingLogInDOM(logKey, content, isComplete = false) {
+            const entry = streamingLogs[logKey];
+            if (!entry) return;
+            
+            const entryDiv = document.getElementById(`log-${entry.id}`);
+            if (!entryDiv) return;
+            
+            const isLongContent = content.length > 200;
+            const contentPreview = isLongContent ? content.substring(0, 200) + '...' : content;
+            
+            // Update title if complete
+            const titleSpan = entryDiv.querySelector('.font-semibold');
+            if (isComplete && titleSpan) {
+                titleSpan.textContent = `${entry.title.split(' ')[0]} Complete ✅`;
+                entryDiv.className = entryDiv.className.replace('border-purple-500 bg-purple-50 dark:bg-purple-900/20', 'border-green-600 bg-green-100 dark:bg-green-900/30');
+                titleSpan.className = titleSpan.className.replace('text-purple-800 dark:text-purple-200', 'text-green-900 dark:text-green-100');
+            }
+            
+            // Update content
+            const previewDiv = entryDiv.querySelector(`#log-${entry.id}-preview`);
+            const fullDiv = entryDiv.querySelector(`#log-${entry.id}-full`);
+            
+            if (previewDiv) {
+                previewDiv.textContent = contentPreview;
+            }
+            if (fullDiv) {
+                fullDiv.textContent = content;
+            }
+            
+            // Auto-scroll to bottom
+            const loggingContent = document.getElementById('loggingContent');
+            loggingContent.scrollTop = loggingContent.scrollHeight;
+        }
+
+        // ===== CASCADING DROPDOWN SYSTEM =====
+        function initializeCascadingDropdowns() {
+            if (!sstDatabase || !Array.isArray(sstDatabase)) return;
+            
+            const domainSelect = document.getElementById('sstDomainSelect');
+            const techniqueSelect = document.getElementById('sstTechniqueSelect');
+
+            // Populate domain dropdown
+            domainSelect.innerHTML = '<option value="">Select a domain...</option>';
+            sstDatabase.forEach(domain => {
+                const option = document.createElement('option');
+                option.value = domain.domain;
+                option.textContent = domain.domain;
+                domainSelect.appendChild(option);
+            });
+
+            // Domain selection handler
+            domainSelect.addEventListener('change', function() {
+                const selectedDomain = this.value;
+                techniqueSelect.innerHTML = '<option value="">Select a technique...</option>';
+                techniqueSelect.disabled = !selectedDomain;
+
+                if (selectedDomain) {
+                    const domainData = sstDatabase.find(d => d.domain === selectedDomain);
+                    if (domainData) {
+                        domainData.techniques.forEach(tech => {
+                            const option = document.createElement('option');
+                            option.value = JSON.stringify({ name: tech.name, method: tech.method });
+                            option.textContent = tech.name;
+                            techniqueSelect.appendChild(option);
+                        });
+                        techniqueSelect.disabled = false;
+                    }
+                }
+            });
+
+            // Technique selection handler - auto-apply to SST box
+            techniqueSelect.addEventListener('change', function() {
+                if (this.value) {
+                    try {
+                        const { name, method } = JSON.parse(this.value);
+                        const formattedSST = `**SST TECHNIQUE**: ${name}\n**APPLICATION METHOD**: ${method}`;
+                        document.getElementById('sstCapsule').value = formattedSST;
+                        console.log('[DRBanger] SST auto-applied:', formattedSST);
+                        
+                        // Reset dropdowns
+                        domainSelect.value = '';
+                        techniqueSelect.innerHTML = '<option value="">Select a technique...</option>';
+                        techniqueSelect.disabled = true;
+                    } catch (error) {
+                        console.error('[DRBanger] Error applying selected SST:', error);
+                        showErrorToast('Error applying selected SST');
+                    }
+                }
+            });
+        }
+
+        // ===== SIMPLIFIED BOT EXECUTION TRACKING =====
+        
+        let currentWorkflowBot = 1;
+        let workflowRunning = false;
+        let activeBotExecutions = new Set(); // Track currently running bots for UI feedback only
+        let botExecutionTimeouts = new Map(); // Track timeout IDs for bot executions
+
+        function updateFloatingButton() {
+            const button = document.getElementById('nextBotButton');
+            const text = document.getElementById('nextBotText');
+            const spinner = document.getElementById('nextBotSpinner');
+            
+            // Only disable floating button if it's specifically running
+            const floatingBotRunning = activeBotExecutions.has(currentWorkflowBot);
+            
+            if (floatingBotRunning) {
+                text.classList.add('hidden');
+                spinner.classList.remove('hidden');
+                button.disabled = true;
+                button.classList.add('opacity-50', 'cursor-not-allowed');
+                text.textContent = `⏳ Running Bot ${currentWorkflowBot}...`;
+            } else {
+                text.classList.remove('hidden');
+                spinner.classList.add('hidden');
+                button.disabled = false;
+                button.classList.remove('opacity-50', 'cursor-not-allowed');
+                
+                if (currentWorkflowBot <= 6) {
+                    text.textContent = `▶️ Next: Bot ${currentWorkflowBot}`;
+                } else {
+                    text.textContent = `🔄 Restart: Bot 1`;
+                    currentWorkflowBot = 1;
+                }
+            }
+        }
+
+        function advanceWorkflow() {
+            // Allow workflow to proceed even if other bots are running
+            console.log(`[DRBanger] Floating button executing Bot ${currentWorkflowBot}`);
+            executeBot(currentWorkflowBot);
+        }
+
+        function onBotComplete(botNumber) {
+            console.log(`[DRBanger] Bot ${botNumber} completed, syncing workflow`);
+            
+            // If this was the workflow bot, advance the sequence
+            if (botNumber === currentWorkflowBot) {
+                if (currentWorkflowBot === 6) {
+                    currentWorkflowBot = 1;
+                    showStateToast('🎉 Workflow complete! Ready to restart.');
+                } else {
+                    currentWorkflowBot++;
+                }
+            }
+            
+            updateFloatingButton();
+            updateAllButtonStates(); // Sync all buttons
+        }
+
+        function onBotStart(botNumber) {
+            console.log(`[DRBanger] Bot ${botNumber} started, tracking for UI`);
+            activeBotExecutions.add(botNumber);
+            
+            updateFloatingButton();
+            updateAllButtonStates();
+        }
+
+        function onBotEnd(botNumber) {
+            console.log(`[DRBanger] Bot ${botNumber} ended, updating UI`);
+            activeBotExecutions.delete(botNumber);
+            
+            // PHASE 2A: Clear timeout when bot ends
+            if (botExecutionTimeouts.has(botNumber)) {
+                clearTimeout(botExecutionTimeouts.get(botNumber));
+                botExecutionTimeouts.delete(botNumber);
+                console.log(`[DRBanger] Cleared timeout for Bot ${botNumber} on normal completion`);
+            }
+            
+            updateFloatingButton();
+            updateAllButtonStates();
+        }
+
+        // ===== SIMPLIFIED BUTTON STATE MANAGEMENT =====
+        function updateAllButtonStates() {
+            for (let i = 1; i <= 6; i++) {
+                const isRunning = activeBotExecutions.has(i);
+                
+                // Update input tab buttons - show loading state but DON'T disable multiple executions
+                const inputButton = document.getElementById(`executeBot${i}`);
+                const inputText = document.getElementById(`executeBot${i}Text`);
+                const inputSpinner = document.getElementById(`executeBot${i}Spinner`);
+                
+                if (inputButton) {
+                    // Always keep buttons enabled for multiple executions
+                    inputButton.disabled = false;
+                    inputButton.classList.remove('opacity-50', 'cursor-not-allowed');
+                    
+                    if (isRunning) {
+                        if (inputText) inputText.classList.add('invisible');
+                        if (inputSpinner) inputSpinner.classList.remove('hidden');
+                    } else {
+                        if (inputText) inputText.classList.remove('invisible');
+                        if (inputSpinner) inputSpinner.classList.add('hidden');
+                    }
+                }
+                
+                // Update results tab buttons - same logic
+                const resultsButton = document.getElementById(`executeBot${i}Results`);
+                if (resultsButton) {
+                    resultsButton.disabled = false;
+                    resultsButton.classList.remove('opacity-50', 'cursor-not-allowed');
+                }
+                
+                // Update Bot 6 panel button
+                if (i === 6) {
+                    const panelButton = document.getElementById('executeBot6Panel');
+                    const panelText = document.getElementById('executeBot6PanelText');
+                    const panelSpinner = document.getElementById('executeBot6PanelSpinner');
+                    
+                    
+                    if (panelButton) {
+                        panelButton.disabled = false;
+                        panelButton.classList.remove('opacity-50', 'cursor-not-allowed');
+                        
+                        if (isRunning) {
+                            if (panelText) panelText.classList.add('invisible');
+                            if (panelSpinner) panelSpinner.classList.remove('hidden');
+                        } else {
+                            if (panelText) panelText.classList.remove('invisible');
+                            if (panelSpinner) panelSpinner.classList.add('hidden');
+                        }
+                    }
+                }
+            }
+        }
+
+        // ===== POE HANDLERS =====
+        
+        ['bot1', 'bot2', 'bot3', 'bot4', 'bot5', 'bot6'].forEach(botId => {
+            window.Poe.registerHandler(`${botId}-handler`, (result) => {
+                const stepMap = { bot1: 'step1Status', bot2: 'step2Status', bot3: 'step3Status', bot4: 'step4Status', bot5: 'step5Status', bot6: 'step6Status' };
+                
+                handleBotResponse(result, botId, () => {
+                    updateStepStatus(stepMap[botId], 'complete');
+                    
+                    // Special handling for Bot 6 - extract SST and put in main box
+                    if (botId === 'bot6' && result.responses && result.responses.length > 0) {
+                        const content = result.responses[0].content;
+                        const sstMatch = content.match(/\*\*SST TECHNIQUE\*\*:\s*(.*?)\n\*\*APPLICATION METHOD\*\*:\s*(.*?)(?:\n|$)/s);
+                        if (sstMatch) {
+                            const formattedSST = `**SST TECHNIQUE**: ${sstMatch[1].trim()}\n**APPLICATION METHOD**: ${sstMatch[2].trim()}`;
+                            document.getElementById('sstCapsule').value = formattedSST;
+                            console.log('[DRBanger] Bot 6 auto-fed SST to main box:', formattedSST);
+                        }
+                    }
+                    
+                    // Advance floating button workflow
+                    const botNumber = parseInt(botId.replace('bot', ''));
+                    onBotComplete(botNumber);
+                });
+            });
+        });
+
+        // ===== BOT EXECUTION FUNCTIONS =====
+        
+        async function executeBot(botNumber) {
+            console.log(`[DRBanger] Executing Bot ${botNumber}`);
+            
+            const legalText = document.getElementById('legalText').value.trim();
+            const sstTechnique = document.getElementById('sstCapsule').value.trim();
+            
+            const botSelector = botSelectors.find(s => s.botId === `bot${botNumber}`);
+            const botName = botSelector ? botSelector.selectedModel : selectedBotModels[botNumber - 1];
+            
+            // NEW: Get the injected instruction for the current bot
+            const customInstruction = injectedInstructions[botNumber];
+
+            addLogEntry('bot_start', `Bot ${botNumber} Started`, `Executing ${botName || 'No model'} with ${legalText ? 'legal text' : 'no legal text'} and ${sstTechnique ? 'SST technique' : 'no SST'}`);
+            
+            const cleanBotName = botName ? botName.replace(/^@/, '') : '';
+            
+            if (!cleanBotName) {
+                showErrorToast(`Bot ${botNumber}: No model selected`);
+                onBotEnd(botNumber); // Use onBotEnd to sync UI
+                addLogEntry('bot_error', `Bot ${botNumber} Error`, 'No model selected');
+                return;
+            }
+            
+            const stepMap = { 1: 'step1Status', 2: 'step2Status', 3: 'step3Status', 4: 'step4Status', 5: 'step5Status', 6: 'step6Status' };
+            
+            let prompt;
+            
+            onBotStart(botNumber); // Use onBotStart to sync UI
+            updateStepStatus(stepMap[botNumber], 'active');
+            document.getElementById(`bot${botNumber}Status`).textContent = "🚀 Starting analysis...";
+            
+            // PHASE 2A: Set timeout for bot execution (180 seconds)
+            const timeoutId = setTimeout(() => {
+                console.warn(`[DRBanger] Bot ${botNumber} timed out after 180 seconds`);
+                showErrorToast(`Bot ${botNumber} timed out - resetting state`);
+                resetBotState(botNumber);
+                addLogEntry('bot_error', `Bot ${botNumber} Timeout`, 'Execution timed out after 3 minutes');
+            }, 180000); // 180 seconds = 3 minutes
+            
+            botExecutionTimeouts.set(botNumber, timeoutId);
+            console.log(`[DRBanger] Set timeout for Bot ${botNumber}:`, timeoutId);
+            
+            try {
+                switch (botNumber) {
+                    case 1:
+                        if (!legalText || !sstTechnique) {
+                            showErrorToast("Bot 1: Missing legal text or SST technique - proceeding anyway");
+                            console.warn('[DRBanger] Bot 1 missing inputs but proceeding');
+                        }
+                        if (customPrompts.bot1) {
+                            prompt = customPrompts.bot1
+                                .replace(/\${legalText}/g, legalText || "[NO LEGAL TEXT PROVIDED]")
+                                .replace(/\${sstTechnique}/g, sstTechnique || "[NO SST TECHNIQUE PROVIDED]");
+                        } else {
+                            prompt = botPrompts.bot1(legalText || "[NO LEGAL TEXT PROVIDED]", sstTechnique || "[NO SST TECHNIQUE PROVIDED]", customInstruction);
+                        }
+                        break;
+                        
+                    case 2:
+                        const bot1Output = document.getElementById('bot1Output').textContent;
+                        if (!bot1Output) {
+                            showErrorToast("Bot 2: No Bot 1 output available - proceeding anyway");
+                            console.warn('[DRBanger] Bot 2 missing Bot 1 output but proceeding');
+                        }
+                        if (customPrompts.bot2) {
+                            prompt = customPrompts.bot2
+                                .replace(/\${bot1Output}/g, bot1Output || "[NO BOT 1 OUTPUT]")
+                                .replace(/\${legalText}/g, legalText || "[NO LEGAL TEXT]");
+                        } else {
+                            prompt = botPrompts.bot2(bot1Output || "[NO BOT 1 OUTPUT]", legalText || "[NO LEGAL TEXT]", customInstruction);
+                        }
+                        break;
+                        
+                    case 3:
+                        const bot2Output = document.getElementById('bot2Output').textContent;
+                        const bot1Output3 = document.getElementById('bot1Output').textContent;
+                        if (!bot2Output || !bot1Output3) {
+                            showErrorToast("Bot 3: Missing previous bot outputs - proceeding anyway");
+                            console.warn('[DRBanger] Bot 3 missing previous outputs but proceeding');
+                        }
+                        if (customPrompts.bot3) {
+                            prompt = customPrompts.bot3
+                                .replace(/\${bot2Output}/g, bot2Output || "[NO BOT 2 OUTPUT]")
+                                .replace(/\${bot1Output}/g, bot1Output3 || "[NO BOT 1 OUTPUT]");
+                        } else {
+                            prompt = botPrompts.bot3(bot2Output || "[NO BOT 2 OUTPUT]", bot1Output3 || "[NO BOT 1 OUTPUT]", customInstruction);
+                        }
+                        break;
+                        
+                    case 4:
+                        const bot2Output4 = document.getElementById('bot2Output').textContent;
+                        const bot3Output = document.getElementById('bot3Output').textContent;
+                        if (!bot2Output4 || !bot3Output) {
+                            showErrorToast("Bot 4: Missing Bot 2/3 outputs - proceeding anyway");
+                            console.warn('[DRBanger] Bot 4 missing previous outputs but proceeding');
+                        }
+                         if (customPrompts.bot4) {
+                            prompt = customPrompts.bot4
+                                .replace(/\${bot2Output}/g, bot2Output4 || "[NO BOT 2 OUTPUT]")
+                                .replace(/\${bot3Output}/g, bot3Output || "[NO BOT 3 OUTPUT]")
+                                .replace(/\${legalText}/g, legalText || "[NO LEGAL TEXT]")
+                                .replace(/\${sstTechnique}/g, sstTechnique || "[NO SST]");
+                        } else {
+                            prompt = botPrompts.bot4(bot2Output4 || "[NO BOT 2 OUTPUT]", bot3Output || "[NO BOT 3 OUTPUT]", legalText || "[NO LEGAL TEXT]", sstTechnique || "[NO SST]", customInstruction);
+                        }
+                        break;
+                        
+                    case 5:
+                        const bot4Output = document.getElementById('bot4Output').textContent;
+                        if (!bot4Output) {
+                            showErrorToast("Bot 5: No Bot 4 output available - proceeding anyway");
+                            console.warn('[DRBanger] Bot 5 missing Bot 4 output but proceeding');
+                        }
+                         if (customPrompts.bot5) {
+                            prompt = customPrompts.bot5.replace(/\${bot4Output}/g, bot4Output || "[NO BOT 4 OUTPUT]");
+                        } else {
+                            prompt = botPrompts.bot5(bot4Output || "[NO BOT 4 OUTPUT]", customInstruction);
+                        }
+                        break;
+                        
+                    case 6:
+                        const conversationHistory = [1, 2, 3, 4, 5].map(i => {
+                            const output = document.getElementById(`bot${i}Output`).textContent;
+                            return output ? `Bot ${i} Output:\n${output}\n\n` : `Bot ${i} Output: [NO OUTPUT]\n\n`;
+                        }).join('');
+                        
+                        const customDomain = document.getElementById('customDomain').value.trim();
+                        const userInstruction = document.getElementById('customInstruction').value.trim();
+                        
+                        if (customPrompts.bot6) {
+                            prompt = customPrompts.bot6
+                                .replace(/\${conversationHistory}/g, conversationHistory)
+                                .replace(/\${customDomain}/g, customDomain || '[NULL - Select optimal domain based on analysis gaps]')
+                                .replace(/\${customInstruction}/g, userInstruction || '[NULL - Use standard generation protocol]');
+                        } else {
+                            prompt = botPrompts.bot6(conversationHistory, customDomain, userInstruction, customInstruction);
+                        }
+                        break;
+                        
+                    default:
+                        showErrorToast("Invalid bot number");
+                        onBotEnd(botNumber);
+                        return;
+                }
+                
+                let inputPreview = "Inputs:\n";
+                if (legalText) inputPreview += `Legal Text: ${legalText.substring(0, 100)}${legalText.length > 100 ? '...' : ''}\n`;
+                if (sstTechnique) inputPreview += `SST: ${sstTechnique.substring(0, 100)}${sstTechnique.length > 100 ? '...' : ''}\n`;
+                if(customInstruction) inputPreview += `Custom Instruction: ${customInstruction.substring(0, 100)}${customInstruction.length > 100 ? '...' : ''}\n`;
+                addLogEntry('bot_input', `Bot ${botNumber} Input`, inputPreview);
+                
+                console.log(`[DRBanger] Bot ${botNumber} executing with prompt length:`, prompt.length);
+                
+                await window.Poe.sendUserMessage(`@${cleanBotName} ${prompt}`, {
+                    handler: `bot${botNumber}-handler`,
+                    stream: true,
+                    openChat: false
+                });
+                
+            } catch (error) {
+                console.error(`[DRBanger] Bot ${botNumber} execution error:`, error);
+                showErrorToast(`Bot ${botNumber} error: ${error.message}`);
+                updateStepStatus(stepMap[botNumber], 'error');
+                resetBotState(botNumber); // PHASE 2A: Use resetBotState instead of onBotEnd for cleanup
+                addLogEntry('bot_error', `Bot ${botNumber} Error`, `Execution failed: ${error.message}`);
+            }
+        }
+
+        // ===== EVENT LISTENERS =====
+        
+        // Initialize all systems
+        setupInputButtons();
+        setupBotButtons();
+        setupClearButtons();
+        setupLegalTextDatabaseControls();
+        
+        // No longer needed - preview system replaced with logging
+        
+        // ===== NEW STATE MANAGEMENT FUNCTIONS =====
+        
+        function downloadStateAsFile() {
+            try {
+                const state = captureCurrentState();
+                const stateJson = JSON.stringify(state, null, 2);
+                const timestamp = getFormattedTimestamp();
+                const filename = `DRBanger_State_${timestamp}.json`;
+                
+                const blob = new Blob([stateJson], { type: 'application/json' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = filename;
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
+                
+                console.log('[DRBanger] State downloaded as file:', filename);
+                showStateToast('📥 State downloaded as file');
+            } catch (error) {
+                console.error('[DRBanger] Error downloading state:', error);
+                showErrorToast('Error downloading state');
+            }
+        }
+
+        function importStateFromClipboard() {
+            document.getElementById('loadStateModal').classList.remove('hidden');
+            document.getElementById('loadStateTextarea').value = '';
+            document.getElementById('loadStateTextarea').placeholder = 'Paste your DRBanger state JSON here...';
+        }
+
+        function loadStateFromFile() {
+            const fileInput = document.getElementById('stateFileInput');
+            fileInput.click();
+        }
+
+        // Hidden file input handler for state upload
+        document.getElementById('stateFileInput').addEventListener('change', function(event) {
+            const file = event.target.files[0];
+            if (file && file.type === 'application/json') {
+                const reader = new FileReader();
+                reader.onload = function(e) {
+                    try {
+                        const state = JSON.parse(e.target.result);
+                        const success = restoreState(state);
+                        
+                        if (success) {
+                            showStateToast('📁 State loaded from file successfully');
+                        } else {
+                            showErrorToast('Failed to restore state completely');
+                        }
+                        
+                    } catch (error) {
+                        console.error('[DRBanger] Invalid state file:', error);
+                        showErrorToast('Invalid JSON format in state file');
+                    }
+                };
+                reader.readAsText(file);
+            } else {
+                showErrorToast('Please select a valid JSON file');
+            }
+            
+            // Reset file input for future use
+            event.target.value = '';
+        });
+```
+
+## How it works
+- **Step-aware status chips** are updated through `updateStepStatus`, colouring the six workflow badges as each bot moves from idle → active → complete/error across both tabs.
+- **Poe streaming adapter** (`handleBotResponse`) keeps status text and rendered Markdown in sync, finishing with `onBotEnd` cleanup and optional SST auto-feed from Bot 6.
+- **Floating Next Bot control** tracks `currentWorkflowBot` and active executions so operators can march through the chain or pick bots manually without desynchronising the UI.
+- **Timeout protection** registers a three-minute safety timer per bot; if Poe never returns, the handler clears spinners, resets buttons, and emits a log entry explaining the timeout.
+- **Prompt assembly** in `executeBot` stitches inputs, prior bot outputs, and optional injected instructions into template strings, then streams to `window.Poe.sendUserMessage` while logging both the request preview and the running response.


### PR DESCRIPTION
## Summary
- document VG-LegalApp input configuration, workflow runner, model selection, and state management modules under `components/`
- extract VG-Frankensteiner magic box, accordion, flag manager, and bot panel templates into reusable documentation snippets
- transcribe VG-LegalApp bot prompts alongside the Frankensteiner Magic Box architect brief so operators can see the exact instructions

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68ccc4b15a70833298275f49163c9f3d